### PR TITLE
Feat/#21 메인페이지 컴포넌트 제작 및 데이터 타입 정의

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import TestPage from './src/pages/TestPage';
+import MainPage from './src/pages/MainPage';
 
 export default function App(): JSX.Element {
-  return <TestPage />;
+  return <MainPage />;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,13 @@
       "version": "1.0.0",
       "dependencies": {
         "expo": "~49.0.15",
+        "expo-linear-gradient": "~12.3.0",
         "expo-status-bar": "~1.6.0",
         "jest": "^29.2.1",
         "jest-expo": "~49.0.0",
         "react": "18.2.0",
         "react-native": "0.72.6",
+        "react-native-svg": "13.9.0",
         "react-test-renderer": "^18.2.0"
       },
       "devDependencies": {
@@ -7924,6 +7926,11 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="
+    },
     "node_modules/bplist-creator": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/bplist-creator/-/bplist-creator-0.1.0.tgz",
@@ -8692,6 +8699,52 @@
         "node": ">=8"
       }
     },
+    "node_modules/css-select": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
+      "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
+      "integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
+      "dependencies": {
+        "mdn-data": "2.0.14",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/css-tree/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
+      "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/cssom": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
@@ -9041,6 +9094,30 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ]
+    },
     "node_modules/domexception": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz",
@@ -9059,6 +9136,33 @@
       "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
+      "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
     "node_modules/dotenv": {
@@ -9966,6 +10070,14 @@
       "version": "12.3.0",
       "resolved": "https://registry.npmjs.org/expo-keep-awake/-/expo-keep-awake-12.3.0.tgz",
       "integrity": "sha512-ujiJg1p9EdCOYS05jh5PtUrfiZnK0yyLy+UewzqrjUqIT8eAGMQbkfOn3C3fHE7AKd5AefSMzJnS3lYZcZYHDw==",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-linear-gradient": {
+      "version": "12.3.0",
+      "resolved": "https://registry.npmjs.org/expo-linear-gradient/-/expo-linear-gradient-12.3.0.tgz",
+      "integrity": "sha512-f9e+Oxe5z7fNQarTBZXilMyswlkbYWQHONVfq8MqmiEnW3h9XsxxmVJLG8uVQSQPUsbW+x1UUT/tnU6mkMWeLg==",
       "peerDependencies": {
         "expo": "*"
       }
@@ -15046,6 +15158,11 @@
       "resolved": "https://registry.npmjs.org/md5hex/-/md5hex-1.0.0.tgz",
       "integrity": "sha512-c2YOUbp33+6thdCUi34xIyOU/a7bvGKj/3DB1iaPMTuPHf/Q2d5s4sn1FaCOO43XkXggnb08y5W2PU8UNYNLKQ=="
     },
+    "node_modules/mdn-data": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
+      "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow=="
+    },
     "node_modules/media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -16126,6 +16243,17 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
     "node_modules/nullthrows": {
@@ -17272,6 +17400,19 @@
       },
       "peerDependencies": {
         "react": "18.2.0"
+      }
+    },
+    "node_modules/react-native-svg": {
+      "version": "13.9.0",
+      "resolved": "https://registry.npmjs.org/react-native-svg/-/react-native-svg-13.9.0.tgz",
+      "integrity": "sha512-Ey18POH0dA0ob/QiwCBVrxIiwflhYuw0P0hBlOHeY4J5cdbs8ngdKHeWC/Kt9+ryP6fNoEQ1PUgPYw2Bs/rp5Q==",
+      "dependencies": {
+        "css-select": "^5.1.0",
+        "css-tree": "^1.1.3"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/react-native/node_modules/promise": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,9 @@
     "jest-expo": "~49.0.0",
     "react": "18.2.0",
     "react-native": "0.72.6",
-    "react-test-renderer": "^18.2.0"
+    "react-test-renderer": "^18.2.0",
+    "expo-linear-gradient": "~12.3.0",
+    "react-native-svg": "13.9.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/src/assets/icon/mainarrow.svg
+++ b/src/assets/icon/mainarrow.svg
@@ -1,0 +1,3 @@
+<svg width="6" height="10" viewBox="0 0 6 10" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M1 1L5 5L1 9" stroke="#797C87" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/assets/icon/mainsearch.svg
+++ b/src/assets/icon/mainsearch.svg
@@ -1,0 +1,3 @@
+<svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M12.0558 12.0846L17 17M14.0079 7.46601C14.0079 11.0371 11.096 13.932 7.50394 13.932C3.91191 13.932 1 11.0371 1 7.46601C1 3.89493 3.91191 1 7.50394 1C11.096 1 14.0079 3.89493 14.0079 7.46601Z" stroke="white" stroke-width="1.3" stroke-linecap="round"/>
+</svg>

--- a/src/assets/icon/mainuser.svg
+++ b/src/assets/icon/mainuser.svg
@@ -1,0 +1,4 @@
+<svg width="18" height="20" viewBox="0 0 18 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M13 13H5C2.79086 13 1 14.7909 1 17V19H17V17C17 14.7909 15.2091 13 13 13Z" stroke="white" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M9 9C11.2091 9 13 7.20914 13 5C13 2.79086 11.2091 1 9 1C6.79086 1 5 2.79086 5 5C5 7.20914 6.79086 9 9 9Z" stroke="white" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/dummy/FollowUpIssueDummy.ts
+++ b/src/dummy/FollowUpIssueDummy.ts
@@ -1,0 +1,34 @@
+import { FollowUpIssue } from '../shared/types/news';
+
+const followUpIssue: FollowUpIssue[] = [
+  {
+    id: 1,
+    title: '후속 이슈 제목',
+    voted: true,
+    reprocessedIssueTitle: '재가공 이슈 제목',
+    createdAt: '2024-02-14T05:50:44.065Z',
+  },
+  {
+    id: 2,
+    title: '후속 이슈 제목',
+    voted: true,
+    reprocessedIssueTitle: '재가공 이슈 제목',
+    createdAt: '2024-02-14T05:50:44.065Z',
+  },
+  {
+    id: 3,
+    title: '후속 이슈 제목',
+    voted: true,
+    reprocessedIssueTitle: '재가공 이슈 제목',
+    createdAt: '2024-02-14T05:50:44.065Z',
+  },
+  {
+    id: 4,
+    title: '후속 이슈 제목',
+    voted: true,
+    reprocessedIssueTitle: '재가공 이슈 제목',
+    createdAt: '2024-02-14T05:50:44.065Z',
+  },
+];
+
+export default followUpIssue;

--- a/src/dummy/ReProcessedIssueDummy.ts
+++ b/src/dummy/ReProcessedIssueDummy.ts
@@ -1,6 +1,6 @@
-import { ReWriteNews } from '../shared/types/news';
+import { ReProcessedIssue } from '../shared/types/news';
 
-const fakeNewsList: ReWriteNews[] = [
+const reprocessedIssue: ReProcessedIssue[] = [
   {
     id: 1,
     title: '재가공 이슈 제목',
@@ -53,4 +53,4 @@ const fakeNewsList: ReWriteNews[] = [
   },
 ];
 
-export default fakeNewsList;
+export default reprocessedIssue;

--- a/src/features/remakeissue/components/FakeIssueIcon.tsx
+++ b/src/features/remakeissue/components/FakeIssueIcon.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { View, Text, StyleSheet, Dimensions } from 'react-native';
 import theme from '../../../shared/styles/theme';
-import { ReWriteNews } from '../../../shared/types/news';
+import { ReProcessedIssue } from '../../../shared/types/news';
 
 interface FakeIssueIconProps {
-  data: ReWriteNews[] | null;
+  data: ReProcessedIssue[] | null;
   slideIndex: number;
 }
 

--- a/src/features/remakeissue/components/FakeIssueItem.tsx
+++ b/src/features/remakeissue/components/FakeIssueItem.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import { Animated, Image, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
-import { ReWriteNews } from '../../../shared/types/news';
+import { ReProcessedIssue } from '../../../shared/types/news';
 import theme from '../../../shared/styles/theme';
 import { ITEM_SIZE, SPACER_ITEM_SIZE } from '../constants/cardAniSize';
 import { LinearGradient } from 'expo-linear-gradient';
 import { formatDate } from '../constants/formatDate';
 
 interface FakeIssueItemProps {
-  item: ReWriteNews;
+  item: ReProcessedIssue;
   index: number;
   scrollX: Animated.Value;
 }

--- a/src/features/remakeissue/components/FakeIssueSlider.tsx
+++ b/src/features/remakeissue/components/FakeIssueSlider.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { Animated, Dimensions, StyleSheet, View } from 'react-native';
-import { ReWriteNews } from '../../../shared/types/news';
+import { ReProcessedIssue } from '../../../shared/types/news';
 import FakeIssueItem from './FakeIssueItem';
 import { ITEM_SIZE } from '../constants/cardAniSize';
 import Indicator from './Indicator';
@@ -8,7 +8,7 @@ import FakeIssueIcon from './FakeIssueIcon';
 import { invisibleLeftCardData, invisibleRightCardData } from '../constants/invisibleCardData';
 
 interface FakeIssueProps {
-  fakeNews: ReWriteNews[] | null;
+  fakeNews: ReProcessedIssue[] | null;
 }
 const FakeIssueSlider = ({ fakeNews }: FakeIssueProps) => {
   const [slideIndex, setSlideIndex] = useState(0);

--- a/src/features/remakeissue/components/Indicator.tsx
+++ b/src/features/remakeissue/components/Indicator.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { StyleSheet, View } from 'react-native';
-import { ReWriteNews } from '../../../shared/types/news';
+import { ReProcessedIssue } from '../../../shared/types/news';
 import theme from '../../../shared/styles/theme';
 
 interface IndicatorProps {
-  data: ReWriteNews[] | null;
+  data: ReProcessedIssue[] | null;
   slideIndex: number;
 }
 

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -1,19 +1,71 @@
 import React from 'react';
-import { StyleSheet, Text, View } from 'react-native';
+import {
+  Dimensions,
+  ImageSourcePropType,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
 import theme from '../shared/styles/theme';
 import FakeIssueSlider from '../features/remakeissue/components/FakeIssueSlider';
 import GlobalTextStyles from '../shared/styles/GlobalTextStyles';
 import ReProcessedIssueDummy from '../dummy/ReProcessedIssueDummy';
 import FollowUpIssueDummy from '../dummy/FollowUpIssueDummy';
+import { WithLocalSvg } from 'react-native-svg';
+import MainArrowSvg from '../assets/icon/mainarrow.svg';
 
 const MainPage = () => {
   const reprocessedIssue = ReProcessedIssueDummy;
   const followUpIssue = FollowUpIssueDummy;
 
+  const pressArrow = () => {
+    console.log('화살표 누름');
+  };
+
   return (
     <View style={styles.container}>
-      <Text style={GlobalTextStyles.NormalText17}>가짜뉴스 이슈(타이틀 변경 예정)</Text>
+      <View style={styles.titleContainer}>
+        <Text style={GlobalTextStyles.NormalText17}>새로운 후속보도가 있어요!</Text>
+      </View>
+      <View style={styles.titleContainer}>
+        <Text style={GlobalTextStyles.NormalText17}>가짜뉴스 이슈(타이틀 변경 예정)</Text>
+      </View>
       <FakeIssueSlider fakeNews={reprocessedIssue} />
+      <View style={styles.titleContainer}>
+        <Text style={GlobalTextStyles.NormalText17}>카테고리1</Text>
+        <TouchableOpacity onPress={pressArrow}>
+          <WithLocalSvg
+            style={styles.svgStyle}
+            width={14}
+            height={14}
+            asset={MainArrowSvg as ImageSourcePropType}
+          />
+        </TouchableOpacity>
+      </View>
+      <View style={styles.titleContainer}>
+        <Text style={GlobalTextStyles.NormalText17}>카테고리2</Text>
+        <TouchableOpacity onPress={pressArrow}>
+          <WithLocalSvg
+            style={styles.svgStyle}
+            width={14}
+            height={14}
+            asset={MainArrowSvg as ImageSourcePropType}
+          />
+        </TouchableOpacity>
+      </View>
+      <View style={styles.divideLine}></View>
+      <View style={styles.titleContainer}>
+        <Text style={GlobalTextStyles.NormalText17}>후속이슈</Text>
+        <TouchableOpacity onPress={pressArrow}>
+          <WithLocalSvg
+            style={styles.svgStyle}
+            width={14}
+            height={14}
+            asset={MainArrowSvg as ImageSourcePropType}
+          />
+        </TouchableOpacity>
+      </View>
     </View>
   );
 };
@@ -24,6 +76,25 @@ const styles = StyleSheet.create({
     backgroundColor: theme.color.black,
     alignItems: 'flex-start',
     justifyContent: 'center',
+  },
+  titleContainer: {
+    width: Dimensions.get('window').width,
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+  },
+  svgStyle: {
+    width: 24,
+    height: 24,
+    marginRight: 21,
+    alignSelf: 'center',
+    justifyContent: 'center',
+  },
+  divideLine: {
+    width: Dimensions.get('window').width,
+    height: 10,
+    marginVertical: 12,
+    flexShrink: 0,
+    backgroundColor: '#21202F',
   },
 });
 

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -15,6 +15,8 @@ import ReProcessedIssueDummy from '../dummy/ReProcessedIssueDummy';
 import FollowUpIssueDummy from '../dummy/FollowUpIssueDummy';
 import { WithLocalSvg } from 'react-native-svg';
 import MainArrowSvg from '../assets/icon/mainarrow.svg';
+import MainUser from '../assets/icon/mainuser.svg';
+import MainSearch from '../assets/icon/mainsearch.svg';
 
 const MainPage = () => {
   const reprocessedIssue = ReProcessedIssueDummy;
@@ -26,7 +28,22 @@ const MainPage = () => {
 
   return (
     <View style={styles.container}>
-      <View style={styles.headerContainer}></View>
+      <View style={styles.headerContainer}>
+        <View style={styles.headerLeftContainer}>
+          <Text style={styles.headerDateText}>11월 19일</Text>
+          <TouchableOpacity style={styles.headerArrow} onPress={pressArrow}>
+            <WithLocalSvg width={12} height={12} asset={MainArrowSvg as ImageSourcePropType} />
+          </TouchableOpacity>
+        </View>
+        <View style={styles.headerRightContainer}>
+          <TouchableOpacity style={styles.headerSvg} onPress={pressArrow}>
+            <WithLocalSvg width={20} height={20} asset={MainSearch as ImageSourcePropType} />
+          </TouchableOpacity>
+          <TouchableOpacity style={styles.headerSvg} onPress={pressArrow}>
+            <WithLocalSvg width={20} height={20} asset={MainUser as ImageSourcePropType} />
+          </TouchableOpacity>
+        </View>
+      </View>
       <View style={styles.headerUnderLine} />
       <ScrollView>
         <View style={styles.titleContainer}>
@@ -38,36 +55,21 @@ const MainPage = () => {
         <FakeIssueSlider fakeNews={reprocessedIssue} />
         <View style={styles.titleContainer}>
           <Text style={GlobalTextStyles.NormalText17}>카테고리1</Text>
-          <TouchableOpacity onPress={pressArrow}>
-            <WithLocalSvg
-              style={styles.svgStyle}
-              width={14}
-              height={14}
-              asset={MainArrowSvg as ImageSourcePropType}
-            />
+          <TouchableOpacity style={styles.svgStyle} onPress={pressArrow}>
+            <WithLocalSvg width={14} height={14} asset={MainArrowSvg as ImageSourcePropType} />
           </TouchableOpacity>
         </View>
         <View style={styles.titleContainer}>
           <Text style={GlobalTextStyles.NormalText17}>카테고리2</Text>
-          <TouchableOpacity onPress={pressArrow}>
-            <WithLocalSvg
-              style={styles.svgStyle}
-              width={14}
-              height={14}
-              asset={MainArrowSvg as ImageSourcePropType}
-            />
+          <TouchableOpacity style={styles.svgStyle} onPress={pressArrow}>
+            <WithLocalSvg width={14} height={14} asset={MainArrowSvg as ImageSourcePropType} />
           </TouchableOpacity>
         </View>
         <View style={styles.divideLine}></View>
         <View style={styles.titleContainer}>
           <Text style={GlobalTextStyles.NormalText17}>후속이슈</Text>
-          <TouchableOpacity onPress={pressArrow}>
-            <WithLocalSvg
-              style={styles.svgStyle}
-              width={14}
-              height={14}
-              asset={MainArrowSvg as ImageSourcePropType}
-            />
+          <TouchableOpacity style={styles.svgStyle} onPress={pressArrow}>
+            <WithLocalSvg width={14} height={14} asset={MainArrowSvg as ImageSourcePropType} />
           </TouchableOpacity>
         </View>
       </ScrollView>
@@ -83,7 +85,7 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
   headerContainer: {
-    width: Dimensions.get('window').width,
+    width: Dimensions.get('window').width - 44,
     height: 30,
     marginTop: 26,
     marginBottom: 14,
@@ -92,10 +94,41 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
   },
+  headerLeftContainer: {
+    flex: 1,
+    flexDirection: 'row',
+    justifyContent: 'flex-start',
+  },
+  headerRightContainer: {
+    flex: 1,
+    flexDirection: 'row',
+    justifyContent: 'flex-end',
+  },
   headerUnderLine: {
     width: Dimensions.get('window').width,
     height: 1,
     backgroundColor: 'rgba(226, 226, 226, 0.1)',
+  },
+  headerDateText: {
+    fontSize: 16,
+    fontStyle: 'normal',
+    fontWeight: '700',
+    lineHeight: 24,
+    letterSpacing: -0.48,
+    color: 'rgba(255,255,255,0.98)',
+  },
+  headerArrow: {
+    width: 24,
+    height: 24,
+    marginLeft: 2,
+    alignSelf: 'center',
+    justifyContent: 'center',
+  },
+  headerSvg: {
+    width: 19,
+    height: 19,
+    marginLeft: 14,
+    alignSelf: 'center',
   },
   titleContainer: {
     width: Dimensions.get('window').width,

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {
   Dimensions,
   ImageSourcePropType,
+  ScrollView,
   StyleSheet,
   Text,
   TouchableOpacity,
@@ -25,47 +26,51 @@ const MainPage = () => {
 
   return (
     <View style={styles.container}>
-      <View style={styles.titleContainer}>
-        <Text style={GlobalTextStyles.NormalText17}>새로운 후속보도가 있어요!</Text>
-      </View>
-      <View style={styles.titleContainer}>
-        <Text style={GlobalTextStyles.NormalText17}>가짜뉴스 이슈(타이틀 변경 예정)</Text>
-      </View>
-      <FakeIssueSlider fakeNews={reprocessedIssue} />
-      <View style={styles.titleContainer}>
-        <Text style={GlobalTextStyles.NormalText17}>카테고리1</Text>
-        <TouchableOpacity onPress={pressArrow}>
-          <WithLocalSvg
-            style={styles.svgStyle}
-            width={14}
-            height={14}
-            asset={MainArrowSvg as ImageSourcePropType}
-          />
-        </TouchableOpacity>
-      </View>
-      <View style={styles.titleContainer}>
-        <Text style={GlobalTextStyles.NormalText17}>카테고리2</Text>
-        <TouchableOpacity onPress={pressArrow}>
-          <WithLocalSvg
-            style={styles.svgStyle}
-            width={14}
-            height={14}
-            asset={MainArrowSvg as ImageSourcePropType}
-          />
-        </TouchableOpacity>
-      </View>
-      <View style={styles.divideLine}></View>
-      <View style={styles.titleContainer}>
-        <Text style={GlobalTextStyles.NormalText17}>후속이슈</Text>
-        <TouchableOpacity onPress={pressArrow}>
-          <WithLocalSvg
-            style={styles.svgStyle}
-            width={14}
-            height={14}
-            asset={MainArrowSvg as ImageSourcePropType}
-          />
-        </TouchableOpacity>
-      </View>
+      <View style={styles.headerContainer}></View>
+      <View style={styles.headerUnderLine} />
+      <ScrollView>
+        <View style={styles.titleContainer}>
+          <Text style={GlobalTextStyles.NormalText17}>새로운 후속보도가 있어요!</Text>
+        </View>
+        <View style={styles.titleContainer}>
+          <Text style={GlobalTextStyles.NormalText17}>가짜뉴스 이슈(타이틀 변경 예정)</Text>
+        </View>
+        <FakeIssueSlider fakeNews={reprocessedIssue} />
+        <View style={styles.titleContainer}>
+          <Text style={GlobalTextStyles.NormalText17}>카테고리1</Text>
+          <TouchableOpacity onPress={pressArrow}>
+            <WithLocalSvg
+              style={styles.svgStyle}
+              width={14}
+              height={14}
+              asset={MainArrowSvg as ImageSourcePropType}
+            />
+          </TouchableOpacity>
+        </View>
+        <View style={styles.titleContainer}>
+          <Text style={GlobalTextStyles.NormalText17}>카테고리2</Text>
+          <TouchableOpacity onPress={pressArrow}>
+            <WithLocalSvg
+              style={styles.svgStyle}
+              width={14}
+              height={14}
+              asset={MainArrowSvg as ImageSourcePropType}
+            />
+          </TouchableOpacity>
+        </View>
+        <View style={styles.divideLine}></View>
+        <View style={styles.titleContainer}>
+          <Text style={GlobalTextStyles.NormalText17}>후속이슈</Text>
+          <TouchableOpacity onPress={pressArrow}>
+            <WithLocalSvg
+              style={styles.svgStyle}
+              width={14}
+              height={14}
+              asset={MainArrowSvg as ImageSourcePropType}
+            />
+          </TouchableOpacity>
+        </View>
+      </ScrollView>
     </View>
   );
 };
@@ -77,8 +82,24 @@ const styles = StyleSheet.create({
     alignItems: 'flex-start',
     justifyContent: 'center',
   },
+  headerContainer: {
+    width: Dimensions.get('window').width,
+    height: 30,
+    marginTop: 26,
+    marginBottom: 14,
+    marginHorizontal: 22,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  headerUnderLine: {
+    width: Dimensions.get('window').width,
+    height: 1,
+    backgroundColor: 'rgba(226, 226, 226, 0.1)',
+  },
   titleContainer: {
     width: Dimensions.get('window').width,
+    marginTop: 20,
     flexDirection: 'row',
     alignItems: 'flex-start',
   },

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -2,16 +2,18 @@ import React from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 import theme from '../shared/styles/theme';
 import FakeIssueSlider from '../features/remakeissue/components/FakeIssueSlider';
-import fakeNewsDummy from '../dummy/FakeNewsDummy';
 import GlobalTextStyles from '../shared/styles/GlobalTextStyles';
+import ReProcessedIssueDummy from '../dummy/ReProcessedIssueDummy';
+import FollowUpIssueDummy from '../dummy/FollowUpIssueDummy';
 
-const TestPage = () => {
-  const fakeNewsList = fakeNewsDummy;
+const MainPage = () => {
+  const reprocessedIssue = ReProcessedIssueDummy;
+  const followUpIssue = FollowUpIssueDummy;
 
   return (
     <View style={styles.container}>
       <Text style={GlobalTextStyles.NormalText17}>가짜뉴스 이슈(타이틀 변경 예정)</Text>
-      <FakeIssueSlider fakeNews={fakeNewsList} />
+      <FakeIssueSlider fakeNews={reprocessedIssue} />
     </View>
   );
 };
@@ -25,4 +27,4 @@ const styles = StyleSheet.create({
   },
 });
 
-export default TestPage;
+export default MainPage;

--- a/src/pages/TestPage.tsx
+++ b/src/pages/TestPage.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import theme from '../shared/styles/theme';
+import FakeIssueSlider from '../features/remakeissue/components/FakeIssueSlider';
+import fakeNewsDummy from '../dummy/FakeNewsDummy';
+import GlobalTextStyles from '../shared/styles/GlobalTextStyles';
+
+const TestPage = () => {
+  const fakeNewsList = fakeNewsDummy;
+
+  return (
+    <View style={styles.container}>
+      <Text style={GlobalTextStyles.NormalText17}>가짜뉴스 이슈(타이틀 변경 예정)</Text>
+      <FakeIssueSlider fakeNews={fakeNewsList} />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: theme.color.black,
+    alignItems: 'flex-start',
+    justifyContent: 'center',
+  },
+});
+
+export default TestPage;

--- a/src/shared/styles/GlobalTextStyles.ts
+++ b/src/shared/styles/GlobalTextStyles.ts
@@ -7,6 +7,7 @@ interface GlobalTextStyles {
 
 const GlobalTextStyles: GlobalTextStyles = {
   NormalText17: {
+    flex: 1,
     fontSize: 17,
     color: theme.color.white,
     fontStyle: 'normal',

--- a/src/shared/types/custom.d.ts
+++ b/src/shared/types/custom.d.ts
@@ -1,0 +1,5 @@
+declare module '*.svg' {
+  import { SvgProps } from 'react-native-svg';
+  const content: React.FC<SvgProps>;
+  export default content;
+}

--- a/src/shared/types/news.ts
+++ b/src/shared/types/news.ts
@@ -1,4 +1,4 @@
-export interface ReWriteNews {
+export interface ReProcessedIssue {
   id: string | number;
   title: string;
   imageUrl: string;
@@ -6,5 +6,13 @@ export interface ReWriteNews {
   views: number;
   opinionCount: number;
   issueId: number;
+  createdAt: string;
+}
+
+export interface FollowUpIssue {
+  id: string | number;
+  title: string;
+  voted: boolean;
+  reprocessedIssueTitle: string;
   createdAt: string;
 }


### PR DESCRIPTION
## 💬리뷰 참고사항

- 재가공이슈, 후속이슈 타입을 변경하였습니다.
- 데이터를 받아와서, Props로 전달하는 MainPage.tsx를 작성하였습니다.
- 개발한 컴포넌트를 쉽게 붙일 수 있도록, 개발하였습니다.
- svg 아이콘을 import하여 사용할 수 있도록, 모듈 설치를 한 후, custom.d.ts 파일을 작성하였습니다.


https://github.com/Neupinion/Neupinion-App/assets/71542970/41e17fce-b8d9-4ebf-9b78-1e5556c6011b



## #️⃣연관된 이슈

> 연관된 이슈 번호를 모두 작성

closes #21 
