### PR TITLE
Feat/#20 svg 아이콘 추가 및, 제목 최대치 지정

### DIFF
--- a/src/features/remakeissue/components/FakeIssueIcon.tsx
+++ b/src/features/remakeissue/components/FakeIssueIcon.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
-import { View, Text, StyleSheet, Dimensions } from 'react-native';
+import { View, Text, StyleSheet, Dimensions, ImageSourcePropType } from 'react-native';
 import theme from '../../../shared/styles/theme';
 import { ReProcessedIssue } from '../../../shared/types/news';
-
+import { WithLocalSvg } from 'react-native-svg';
+import MessageIcon from '../../../assets/icon/message.svg';
+import UserIcon from '../../../assets/icon/user.svg';
 interface FakeIssueIconProps {
   data: ReProcessedIssue[] | null;
   slideIndex: number;
@@ -17,8 +19,10 @@ const FakeIssueIcon = ({ data, slideIndex }: FakeIssueIconProps) => {
 
   return (
     <View style={styles.container}>
+      <WithLocalSvg width={17} height={17} asset={UserIcon as ImageSourcePropType} />
       <Text style={styles.iconText}>{item.views.toLocaleString()}</Text>
       <View style={{ width: 10 }}></View>
+      <WithLocalSvg width={17} height={17} asset={MessageIcon as ImageSourcePropType} />
       <Text style={styles.iconText}>{item.opinionCount.toLocaleString()}</Text>
     </View>
   );

--- a/src/features/remakeissue/components/FakeIssueItem.tsx
+++ b/src/features/remakeissue/components/FakeIssueItem.tsx
@@ -59,7 +59,7 @@ const FakeIssueItem = ({ item, index, scrollX }: FakeIssueItemProps) => {
             >
               <Image source={{ uri: item.imageUrl }} style={styles.cardImage} />
               <View style={styles.cardUnderContainer}>
-                <Text style={styles.titleText}>{item.title}</Text>
+                <Text style={styles.titleText} numberOfLines={1} ellipsizeMode="tail">{item.title}</Text>
                 <View style={styles.titleUnderContainer}>
                   <View style={styles.tagBox}>
                     <Text style={styles.tagText}>{item.category}</Text>


### PR DESCRIPTION
## 💬리뷰 참고사항

가짜뉴스 카드 UI 안에서, 최대 몇자까지 보여주는 최대치 지정
최대치가 넘어가면, ...을 붙일 수 있도록.
svg 아이콘 추가

- FakeIssue와 관련된 2가지 파일이 변경되었습니다.

## #️⃣연관된 이슈

> 연관된 이슈 번호를 모두 작성

closes #20 
