### PR TITLE
Feat/#53-2 앱 공유 기능을 개발한다.

### DIFF
--- a/src/pages/AppLinkTestPage.tsx
+++ b/src/pages/AppLinkTestPage.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { Platform, Share, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import theme from '../shared/styles/theme';
+
+const AppLinkTestPage = () => {
+  const appLink =
+    Platform.OS === 'ios'
+      ? 'https://apps.apple.com/us/app/kakaotalk/id362057947'
+      : 'https://play.google.com/store/search?q=%EC%B9%B4%EC%B9%B4%EC%98%A4%ED%86%A1%ED%86%A1&c=apps&hl=ko';
+
+  const appLinkShare = () => async () => {
+    try {
+      const result = await Share.share({
+        message: appLink,
+      });
+
+      if (result.action === Share.sharedAction) {
+        if (result.activityType) {
+          console.log('activityType!');
+        } else {
+          console.log('Share!');
+        }
+      } else if (result.action === Share.dismissedAction) {
+        console.log('dismissed');
+      }
+    } catch (e: unknown) {
+      if (e instanceof Error) {
+        console.log(e.message);
+      } else {
+        console.log('An unknown error occurred');
+      }
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <TouchableOpacity
+        style={{ width: 220, height: 110, backgroundColor: 'white' }}
+        onPress={appLinkShare}
+      >
+        <Text style={{ backgroundColor: 'black' }}>공유하기</Text>
+      </TouchableOpacity>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: theme.color.black,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});
+
+export default AppLinkTestPage;


### PR DESCRIPTION
## 💬리뷰 참고사항

- 지정된 링크를 휴대폰에 있는 공유 가능한 플랫폼에 공유할 수 있도록 하는 기능을 추가하였습니다.
- 임시로, 아이폰은 appstore 카카오톡, 갤럭시는 playstore 카카오톡 앱 링크를 공유하도록 하였습니다.
- Expo Go에서도 확인 가능합니다.
   - "test: 웹 링크 공유 시도" -> 웹 링크를 공유하는 기능
   - "feat: 카카오톡의 앱...있는 컴포넌트 제작" -> 앱 링크를 공유하는 기능

## #️⃣연관된 이슈

> 연관된 이슈 번호를 모두 작성

closes #53 
