### PR TITLE
Feat/#60 의견 포스트잇 클릭시 바텀시트 등장 및 삭제 팝업 개발

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "neupinion",
       "version": "1.0.0",
       "dependencies": {
+        "@gorhom/bottom-sheet": "^4.6.1",
         "@react-navigation/native": "^6.1.14",
         "@react-navigation/native-stack": "^6.9.22",
         "@react-navigation/stack": "^6.3.25",
@@ -24,7 +25,7 @@
         "react-native-calendars": "^1.1303.0",
         "react-native-dotenv": "^3.4.10",
         "react-native-gesture-handler": "^2.15.0",
-        "react-native-reanimated": "^3.7.2",
+        "react-native-reanimated": "^3.8.1",
         "react-native-safe-area-context": "^4.6.3",
         "react-native-screens": "~3.22.0",
         "react-native-svg": "13.9.0",
@@ -3152,6 +3153,43 @@
     "node_modules/@gar/promisify": {
       "version": "1.1.3",
       "license": "MIT"
+    },
+    "node_modules/@gorhom/bottom-sheet": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@gorhom/bottom-sheet/-/bottom-sheet-4.6.1.tgz",
+      "integrity": "sha512-sXqsYqX1/rAbmCC5fb9o6hwSF3KXriC0EGUGvLlhFvjaEEMBrRKFTNndiluRK1HmpUzazVaYdTm/lLkSiA2ooQ==",
+      "dependencies": {
+        "@gorhom/portal": "1.0.14",
+        "invariant": "^2.2.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-native": "*",
+        "react": "*",
+        "react-native": "*",
+        "react-native-gesture-handler": ">=1.10.1",
+        "react-native-reanimated": ">=2.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@gorhom/portal": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/@gorhom/portal/-/portal-1.0.14.tgz",
+      "integrity": "sha512-MXyL4xvCjmgaORr/rtryDNFy3kU4qUbKlwtQqqsygd0xX3mhKjOLn6mQK8wfu0RkoE0pBE0nAasRoHua+/QZ7A==",
+      "dependencies": {
+        "nanoid": "^3.3.1"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
     },
     "node_modules/@graphql-typed-document-node/core": {
       "version": "3.2.0",
@@ -6358,12 +6396,12 @@
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.11",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.2.47",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -6387,7 +6425,7 @@
     },
     "node_modules/@types/scheduler": {
       "version": "0.16.8",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/semver": {
@@ -8293,7 +8331,7 @@
     },
     "node_modules/csstype": {
       "version": "3.1.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/dag-map": {
@@ -16316,9 +16354,9 @@
       }
     },
     "node_modules/react-native-reanimated": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-3.8.0.tgz",
-      "integrity": "sha512-xoG4+nf+lSmzv37mjTUIT0gYNEIr2Mb8WXgmqR8deCJk8CC6lXT0HRpshTPVAF00LvdzrD2W/rCpiBdHN5FW2w==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-3.8.1.tgz",
+      "integrity": "sha512-EdM0vr3JEaNtqvstqESaPfOBy0gjYBkr1iEolWJ82Ax7io8y9OVUIphgsLKTB36CtR1XtmBw0RZVj7KArc7ZVA==",
       "dependencies": {
         "@babel/plugin-transform-arrow-functions": "^7.0.0-0",
         "@babel/plugin-transform-nullish-coalescing-operator": "^7.0.0-0",

--- a/package.json
+++ b/package.json
@@ -16,9 +16,12 @@
     "transformIgnorePatterns": [
       "node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg|native-notify)"
     ],
-    "setupFilesAfterEnv": ["<rootDir>/jest.setup.js"]
+    "setupFilesAfterEnv": [
+      "<rootDir>/jest.setup.js"
+    ]
   },
   "dependencies": {
+    "@gorhom/bottom-sheet": "^4.6.1",
     "@react-navigation/native": "^6.1.14",
     "@react-navigation/native-stack": "^6.9.22",
     "@react-navigation/stack": "^6.3.25",
@@ -28,16 +31,14 @@
     "expo-linear-gradient": "~12.3.0",
     "expo-status-bar": "~1.6.0",
     "expo-updates": "~0.18.19",
-
     "jest": "^29.2.1",
-
     "jest-expo": "~49.0.0",
     "react": "18.2.0",
     "react-native": "0.72.6",
     "react-native-calendars": "^1.1303.0",
     "react-native-dotenv": "^3.4.10",
     "react-native-gesture-handler": "^2.15.0",
-    "react-native-reanimated": "^3.7.2",
+    "react-native-reanimated": "^3.8.1",
     "react-native-safe-area-context": "^4.6.3",
     "react-native-screens": "~3.22.0",
     "react-native-svg": "13.9.0",

--- a/src/Navigation.tsx
+++ b/src/Navigation.tsx
@@ -4,6 +4,7 @@ import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import OpinionPostPage from './pages/OpinionPostPage';
 import OpinionPinPage from './pages/OpinionPinPage';
 import MainPage from './pages/MainPage';
+import DetailPage from "./pages/DetailPage";
 
 const Stack = createNativeStackNavigator();
 
@@ -15,6 +16,9 @@ const Navigation = () => {
           headerShown: false,
         }}
       >
+        <Stack.Group>
+          <Stack.Screen name="DetailPage" component={DetailPage}></Stack.Screen>
+        </Stack.Group>
         <Stack.Group>
           <Stack.Screen name="OpinionPost" component={OpinionPostPage}></Stack.Screen>
           <Stack.Screen name="OpinionPin" component={OpinionPinPage}></Stack.Screen>

--- a/src/assets/icon/warningpopupexclamation.svg
+++ b/src/assets/icon/warningpopupexclamation.svg
@@ -1,0 +1,4 @@
+<svg width="7" height="29" viewBox="0 0 7 29" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="7" height="17.5" rx="3.5" fill="#D1D3D8"/>
+<circle cx="3.5" cy="25" r="3.5" fill="#D1D3D8"/>
+</svg>

--- a/src/features/opinionView/components/OpinionWriteBottomSheet.tsx
+++ b/src/features/opinionView/components/OpinionWriteBottomSheet.tsx
@@ -15,6 +15,7 @@ import theme from '../../../shared/styles/theme';
 import fontFamily from '../../../shared/styles/fontFamily';
 import { WithLocalSvg } from 'react-native-svg';
 import OpinionPin from '../../../assets/icon/opinionpin.svg';
+import WarningPopup from '../../popup/components/WarningPopup';
 
 interface OpinionWriteBottomSheetProps {
   modalVisible: boolean;
@@ -28,9 +29,13 @@ const OpinionWriteBottomSheet = ({
   content,
 }: OpinionWriteBottomSheetProps) => {
   const [isModalVisible, setModalVisible] = useState(modalVisible);
-  const animationDuration: number = 300;
+  const [isDeletePopupVisible, setIsDeletePopupVisible] = useState(false);
+
   const screenHeight = Dimensions.get('screen').height;
+
+  const animationDuration: number = 300;
   const panY = useRef(new Animated.Value(screenHeight)).current;
+
   const translateY = panY.interpolate({
     inputRange: [-1, 0, 1],
     outputRange: [0, 0, 1],
@@ -64,7 +69,7 @@ const OpinionWriteBottomSheet = ({
   };
 
   const onClickDeleteButton = () => {
-    console.log('삭제버튼 클릭');
+    setIsDeletePopupVisible(true);
   };
 
   const panResponders = useRef(
@@ -113,6 +118,12 @@ const OpinionWriteBottomSheet = ({
             <Text style={styles.deleteButtonText}>삭제하기</Text>
           </TouchableOpacity>
         </Animated.View>
+        <WarningPopup
+          modalVisible={isDeletePopupVisible}
+          title={'작성한 의견을 삭제하시겠습니까?'}
+          onClose={() => setIsDeletePopupVisible(false)}
+          onConfirm={() => {}}
+        />
       </View>
     </Modal>
   );

--- a/src/features/opinionView/components/OpinionWriteBottomSheet.tsx
+++ b/src/features/opinionView/components/OpinionWriteBottomSheet.tsx
@@ -91,7 +91,6 @@ const OpinionWriteBottomSheet = ({
 const styles = StyleSheet.create({
   background: {
     flex: 1,
-    backgroundColor: 'purple',
   },
   overlay: {
     flex: 1,

--- a/src/features/opinionView/components/OpinionWriteBottomSheet.tsx
+++ b/src/features/opinionView/components/OpinionWriteBottomSheet.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import {
   Animated,
   Dimensions,
@@ -42,6 +42,11 @@ const OpinionWriteBottomSheet = ({
     useNativeDriver: true,
   });
 
+  useEffect(() => {
+    if (isModalVisible) {
+      resetBottomSheet.start();
+    }
+  }, [isModalVisible]);
   const closeModal = () => {
     closeBottomSheet.start(() => {
       setModalVisible(false);
@@ -86,7 +91,7 @@ const OpinionWriteBottomSheet = ({
 const styles = StyleSheet.create({
   background: {
     flex: 1,
-    backgroundColor: 'white',
+    backgroundColor: 'purple',
   },
   overlay: {
     flex: 1,

--- a/src/features/opinionView/components/OpinionWriteBottomSheet.tsx
+++ b/src/features/opinionView/components/OpinionWriteBottomSheet.tsx
@@ -78,8 +78,10 @@ const OpinionWriteBottomSheet = ({
         </TouchableWithoutFeedback>
         <Animated.View
           style={{ ...styles.bottomSheetContainer, transform: [{ translateY: translateY }] }}
-          {...panResponders.panHandlers}
         >
+          <View style={styles.panResponderContainer} {...panResponders.panHandlers}>
+            <View style={styles.panResponder}/>
+          </View>
           <Text>{title}</Text>
           <Text>{content}</Text>
         </Animated.View>
@@ -98,12 +100,24 @@ const styles = StyleSheet.create({
     backgroundColor: 'rgba(0, 0, 0, 0.4)',
   },
   bottomSheetContainer: {
-    height: 300,
+    display: 'flex',
     justifyContent: 'center',
     alignItems: 'center',
+    backgroundColor: '#212A3C',
+    borderTopLeftRadius: 24,
+    borderTopRightRadius: 24,
+  },
+  panResponderContainer: {
+    height: 24,
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  panResponder: {
+    width: 44,
+    height: 4,
+    borderRadius: 4,
     backgroundColor: 'white',
-    borderTopLeftRadius: 10,
-    borderTopRightRadius: 10,
   },
 });
 

--- a/src/features/opinionView/components/OpinionWriteBottomSheet.tsx
+++ b/src/features/opinionView/components/OpinionWriteBottomSheet.tsx
@@ -1,0 +1,106 @@
+import React, { useRef, useState } from 'react';
+import {
+  Animated,
+  Dimensions,
+  Modal,
+  PanResponder,
+  View,
+  Text,
+  StyleSheet,
+  TouchableWithoutFeedback,
+} from 'react-native';
+
+interface OpinionWriteBottomSheetProps {
+  modalVisible: boolean;
+  title: string;
+  content: string;
+}
+
+const OpinionWriteBottomSheet = ({
+  modalVisible,
+  title,
+  content,
+}: OpinionWriteBottomSheetProps) => {
+  const [isModalVisible, setModalVisible] = useState(modalVisible);
+  const animationDuration: number = 300;
+  const screenHeight = Dimensions.get('screen').height;
+  const panY = useRef(new Animated.Value(screenHeight)).current;
+  const translateY = panY.interpolate({
+    inputRange: [-1, 0, 1],
+    outputRange: [0, 0, 1],
+  });
+
+  const resetBottomSheet = Animated.timing(panY, {
+    toValue: 0,
+    duration: animationDuration,
+    useNativeDriver: true,
+  });
+
+  const closeBottomSheet = Animated.timing(panY, {
+    toValue: screenHeight,
+    duration: animationDuration,
+    useNativeDriver: true,
+  });
+
+  const closeModal = () => {
+    closeBottomSheet.start(() => {
+      setModalVisible(false);
+    });
+  };
+
+  const panResponders = useRef(
+    PanResponder.create({
+      onStartShouldSetPanResponder: () => true,
+      onMoveShouldSetPanResponder: () => false,
+      onPanResponderMove: (event, gestureState) => {
+        panY.setValue(gestureState.dy);
+      },
+      onPanResponderRelease: (event, gestureState) => {
+        if (gestureState.dy > 0 && gestureState.vy > 1.5) {
+          closeModal();
+        } else {
+          resetBottomSheet.start();
+        }
+      },
+    }),
+  ).current;
+
+  return (
+    <Modal visible={isModalVisible} animationType={'fade'} transparent statusBarTranslucent>
+      <View style={styles.overlay}>
+        <TouchableWithoutFeedback onPress={closeModal}>
+          <View style={styles.background} />
+        </TouchableWithoutFeedback>
+        <Animated.View
+          style={{ ...styles.bottomSheetContainer, transform: [{ translateY: translateY }] }}
+          {...panResponders.panHandlers}
+        >
+          <Text>{title}</Text>
+          <Text>{content}</Text>
+        </Animated.View>
+      </View>
+    </Modal>
+  );
+};
+
+const styles = StyleSheet.create({
+  background: {
+    flex: 1,
+    backgroundColor: 'white',
+  },
+  overlay: {
+    flex: 1,
+    justifyContent: 'flex-end',
+    backgroundColor: 'rgba(0, 0, 0, 0.4)',
+  },
+  bottomSheetContainer: {
+    height: 300,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: 'white',
+    borderTopLeftRadius: 10,
+    borderTopRightRadius: 10,
+  },
+});
+
+export default OpinionWriteBottomSheet;

--- a/src/features/opinionView/components/OpinionWriteBottomSheet.tsx
+++ b/src/features/opinionView/components/OpinionWriteBottomSheet.tsx
@@ -8,7 +8,13 @@ import {
   Text,
   StyleSheet,
   TouchableWithoutFeedback,
+  TouchableOpacity,
+  ImageSourcePropType,
 } from 'react-native';
+import theme from '../../../shared/styles/theme';
+import fontFamily from '../../../shared/styles/fontFamily';
+import { WithLocalSvg } from 'react-native-svg';
+import OpinionPin from '../../../assets/icon/opinionpin.svg';
 
 interface OpinionWriteBottomSheetProps {
   modalVisible: boolean;
@@ -53,6 +59,14 @@ const OpinionWriteBottomSheet = ({
     });
   };
 
+  const onClickModifyButton = () => {
+    console.log('수정버튼 클릭');
+  };
+
+  const onClickDeleteButton = () => {
+    console.log('삭제버튼 클릭');
+  };
+
   const panResponders = useRef(
     PanResponder.create({
       onStartShouldSetPanResponder: () => true,
@@ -80,10 +94,24 @@ const OpinionWriteBottomSheet = ({
           style={{ ...styles.bottomSheetContainer, transform: [{ translateY: translateY }] }}
         >
           <View style={styles.panResponderContainer} {...panResponders.panHandlers}>
-            <View style={styles.panResponder}/>
+            <View style={styles.panResponder} />
           </View>
-          <Text>{title}</Text>
-          <Text>{content}</Text>
+          <View style={styles.titleContainer}>
+            <View style={styles.pinContainer}>
+              <TouchableOpacity style={styles.pin}>
+                <WithLocalSvg width={20} height={20} asset={OpinionPin as ImageSourcePropType} />
+              </TouchableOpacity>
+            </View>
+            <Text style={styles.titleText}>{title}</Text>
+          </View>
+          <View style={styles.dotLine} />
+          <Text style={styles.contentText}>{content}</Text>
+          <TouchableOpacity style={styles.modifyButton} onPress={onClickModifyButton}>
+            <Text style={styles.modifyButtonText}>수정하기</Text>
+          </TouchableOpacity>
+          <TouchableOpacity style={styles.deleteButton} onPress={onClickDeleteButton}>
+            <Text style={styles.deleteButtonText}>삭제하기</Text>
+          </TouchableOpacity>
         </Animated.View>
       </View>
     </Modal>
@@ -118,6 +146,95 @@ const styles = StyleSheet.create({
     height: 4,
     borderRadius: 4,
     backgroundColor: 'white',
+  },
+  titleContainer: {
+    display: 'flex',
+    marginTop: 24,
+    marginHorizontal: 25,
+    justifyContent: 'flex-start',
+    alignItems: 'flex-start',
+  },
+  titleText: {
+    color: theme.color.white,
+    textAlign: 'justify',
+    fontFamily: fontFamily.pretendard.bold,
+    fontStyle: 'normal',
+    fontSize: 15,
+    fontWeight: '600',
+    lineHeight: 22.5,
+    letterSpacing: -0.45,
+  },
+  pinContainer: {
+    display: 'flex',
+    width: 20,
+    flexDirection: 'column',
+    position: 'absolute',
+    left: -5,
+    top: 2,
+  },
+  pin: {
+    width: 20,
+    height: 20,
+  },
+  dotLine: {
+    width: 340,
+    marginVertical: 16,
+    flexShrink: 0,
+    height: 0,
+    backgroundColor: '#D1D3D8',
+    borderWidth: 0.6,
+    borderStyle: 'dashed',
+  },
+  contentText: {
+    color: '#EBECF1',
+    height: 190,
+    textAlign: 'justify',
+    fontFamily: fontFamily.pretendard.bold,
+    fontStyle: 'normal',
+    fontSize: 14,
+    fontWeight: '500',
+    lineHeight: 21,
+    letterSpacing: -0.42,
+    marginHorizontal: 25,
+  },
+  modifyButton: {
+    width: Dimensions.get('window').width - 50,
+    backgroundColor: theme.color.main,
+    justifyContent: 'center',
+    alignItems: 'center',
+    borderRadius: 10,
+    marginTop: 28,
+    height: 50,
+  },
+  modifyButtonText: {
+    color: theme.color.white,
+    textAlign: 'justify',
+    fontFamily: fontFamily.pretendard.bold,
+    fontStyle: 'normal',
+    fontSize: 17,
+    fontWeight: '700',
+    lineHeight: 25.5,
+    letterSpacing: -0.51,
+  },
+  deleteButton: {
+    width: Dimensions.get('window').width - 50,
+    backgroundColor: '#212A3C',
+    justifyContent: 'center',
+    alignItems: 'center',
+    borderRadius: 10,
+    marginTop: 10,
+    marginBottom: 20,
+    height: 50,
+  },
+  deleteButtonText: {
+    color: '#71788F',
+    textAlign: 'justify',
+    fontFamily: fontFamily.pretendard.bold,
+    fontStyle: 'normal',
+    fontSize: 17,
+    fontWeight: '700',
+    lineHeight: 25.5,
+    letterSpacing: -0.51,
   },
 });
 

--- a/src/features/popup/components/WarningPopup.tsx
+++ b/src/features/popup/components/WarningPopup.tsx
@@ -1,0 +1,130 @@
+import { ImageSourcePropType, Modal, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import React, { useEffect, useState } from 'react';
+import theme from '../../../shared/styles/theme';
+import fontFamily from '../../../shared/styles/fontFamily';
+import Exclamation from '../../../assets/icon/warningpopupexclamation.svg';
+import { WithLocalSvg } from 'react-native-svg';
+
+interface WarningPopup {
+  modalVisible: boolean;
+  title: string;
+  onClose: () => void;
+  onConfirm: () => void;
+}
+const WarningPopup = ({ modalVisible, title, onClose, onConfirm }: WarningPopup) => {
+  const [isModalVisible, setModalVisible] = useState(modalVisible);
+
+  useEffect(() => {
+    setModalVisible(modalVisible);
+  }, [modalVisible]);
+  const onClickCancel = () => {
+    setModalVisible(false);
+    onClose();
+  };
+
+  const onClickConfirm = () => {
+    setModalVisible(false);
+    onClose();
+    onConfirm();
+  };
+
+  return (
+    <Modal visible={isModalVisible} animationType={'fade'} transparent statusBarTranslucent>
+      <View style={styles.overlay}>
+        <View style={styles.popupContainer}>
+          <View style={styles.exclamationCircle}>
+            <WithLocalSvg width={7} height={28.5} asset={Exclamation as ImageSourcePropType} />
+          </View>
+          <Text style={styles.titleText}>{title}</Text>
+          <Text style={styles.warningText}>이 작업은 취소할 수 없습니다.</Text>
+          <View style={styles.buttonContainer}>
+            <TouchableOpacity onPress={onClickCancel} style={styles.cancelButton}>
+              <Text style={styles.buttonText}>취소</Text>
+            </TouchableOpacity>
+            <TouchableOpacity onPress={onClickConfirm} style={styles.confirmButton}>
+              <Text style={styles.buttonText}>확인</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      </View>
+    </Modal>
+  );
+};
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: 'rgba(17, 17, 26, 0.8)',
+  },
+  popupContainer: {
+    width: 340,
+    height: 244,
+    borderRadius: 10,
+    backgroundColor: '#394358',
+    flexDirection: 'column',
+    alignItems: 'center',
+  },
+  exclamationCircle: {
+    marginTop: 24,
+    borderRadius: 56,
+    width: 56,
+    height: 56,
+    backgroundColor: '#4E5867',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  titleText: {
+    marginTop: 12,
+    color: theme.color.white,
+    fontFamily: fontFamily.pretendard.bold,
+    fontStyle: 'normal',
+    fontSize: 20,
+    fontWeight: '700',
+    lineHeight: 30,
+    letterSpacing: -0.6,
+  },
+  warningText: {
+    marginTop: 4,
+    color: '#D1D3D8',
+    fontFamily: fontFamily.pretendard.bold,
+    fontStyle: 'normal',
+    fontSize: 16,
+    fontWeight: '600',
+    lineHeight: 24,
+    letterSpacing: -0.48,
+  },
+  buttonContainer: {
+    marginTop: 20,
+    display: 'flex',
+    flexDirection: 'row',
+    gap: 16,
+  },
+  cancelButton: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: 142,
+    height: 50,
+    borderRadius: 10,
+    backgroundColor: '#4E5867',
+  },
+  confirmButton: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: 142,
+    height: 50,
+    borderRadius: 10,
+    backgroundColor: theme.color.main,
+  },
+  buttonText: {
+    color: theme.color.white,
+    fontFamily: fontFamily.pretendard.bold,
+    fontStyle: 'normal',
+    fontSize: 17,
+    fontWeight: '700',
+    lineHeight: 25.5,
+    letterSpacing: -0.51,
+  },
+});
+export default WarningPopup;

--- a/src/pages/DetailPage.tsx
+++ b/src/pages/DetailPage.tsx
@@ -19,6 +19,7 @@ import OpinionWriteSlider from '../features/remakeissue/components/OpinionWriteS
 import ReliabilityEvaluation from '../features/remakeissue/components/ReliabilityEvaluation';
 import CategoryLatestNews from '../features/remakeissue/components/CategoryLatestNews';
 import ReProcessedIssueDummy from '../dummy/ReProcessedIssueDummy';
+import OpinionWriteBottomSheet from "../features/opinionView/components/OpinionWriteBottomSheet";
 
 const DetailPage = () => {
   const [bookMarkClicked, setBookMarkClicked] = useState(false);
@@ -65,6 +66,7 @@ const DetailPage = () => {
         <View style={styles.divideLine}></View>
         <CategoryLatestNews fakeNews={reprocessedIssue} />
       </ScrollView>
+      <OpinionWriteBottomSheet modalVisible={true} title={'안녕'} content={'잘가'}/>
     </View>
   );
 };

--- a/src/pages/DetailPage.tsx
+++ b/src/pages/DetailPage.tsx
@@ -66,7 +66,15 @@ const DetailPage = () => {
         <View style={styles.divideLine}></View>
         <CategoryLatestNews fakeNews={reprocessedIssue} />
       </ScrollView>
-      <OpinionWriteBottomSheet modalVisible={true} title={'안녕'} content={'잘가'}/>
+      <OpinionWriteBottomSheet
+        modalVisible={true}
+        title={
+          '    블룸버그통신 등에 따르면 22일(현지 시간) 오전 9시를 전후 로 미 워싱턴DC에 있는 펜타곤으로 보이는 건물에서 검은 연기가 피어오르는 사진이 트위터를 통해 국내외로 빠르게 확산했다.'
+        }
+        content={
+          '최초로 게시된 곳이 공신력 있는 매체가 아니고 트위터라서 신뢰도가 떨어지는 듯. 계정도 그냥 개인 계정인 것 같아서 추가적인 확인이 필요할 것 같다.'
+        }
+      />
     </View>
   );
 };


### PR DESCRIPTION
## 💬리뷰 참고사항

![image](https://github.com/Neupinion/Neupinion-App/assets/71542970/c89d9b3f-727c-43e9-bd98-c23981dc7972)

의견 포스트잇을 누르면 바텀시트가 올라오는 기능 개발하였습니다.
수정하기를 누르면, 해당 페이지로 이동은 이후에 작업하려 합니다.
삭제하기 눌렀을 때의 팝업 기능 개발하였습니다.

DetailPage에 다음과 같은 코드가 적혀있으며, modalVisible이 true라면 바텀시트가 등장, false면 바텀시트가 없이 시작됩니다. 

다음과 같은 modalVisible, title, content 3가지 요소들을 포스트잇 리스트를 보여주는 ui 개발과 동시에 코드 수정을 하면 좋을 것 같습니다. 더 좋은 방법이 있다면 알려주시면 좋겠습니다!

```javascript
<OpinionWriteBottomSheet
        modalVisible={true}
        title={
          '    블룸버그통신 등에 따르면 22일(현지 시간) 오전 9시를 전후 로 미 워싱턴DC에 있는 펜타곤으로 보이는 건물에서 검은 연기가 피어오르는 사진이 트위터를 통해 국내외로 빠르게 확산했다.'
        }
        content={
          '최초로 게시된 곳이 공신력 있는 매체가 아니고 트위터라서 신뢰도가 떨어지는 듯. 계정도 그냥 개인 계정인 것 같아서 추가적인 확인이 필요할 것 같다.'
        }
      />
```
## #️⃣연관된 이슈

> 연관된 이슈 번호를 모두 작성
closes #60 
