### PR TITLE
Feat/#91 투표 페이지 및 통합 투표 페이지 API 연동

### DIFF
--- a/src/dummy/TotalVotedDataDummy.ts
+++ b/src/dummy/TotalVotedDataDummy.ts
@@ -1,45 +1,31 @@
-export interface TotalTrustVoteData {
-  totalVoteCount: number;
-  mostVotedCount: number;
-  mostVotedStatus: string;
-  voteRankings: TotalVoteData[];
-}
+import { IntegratedResult } from '../features/totalvote/types/integratedResult';
 
-export interface TotalVoteData {
-  issueId: number;
-  issueOrder: string;
-  trust: number;
-  doubt: number;
-}
-
-export const TotalVotedDataDummy: TotalTrustVoteData = {
+export const TotalVotedDataDummy: IntegratedResult = {
+  mostVoted: '완전 신뢰',
   totalVoteCount: 7000,
-  mostVotedStatus: '완전 신뢰',
   mostVotedCount: 5342,
+  voteResults: [
+    {
+      trustRate: 0,
+      doubtRate: 100,
+    },
+  ],
   voteRankings: [
     {
-      issueId: 1,
-      issueOrder: '최초 보도',
-      trust: 30,
-      doubt: 70,
+      status: '매우 의심',
+      votePercentage: 100,
     },
     {
-      issueId: 2,
-      issueOrder: '두 번째 보도',
-      trust: 40,
-      doubt: 60,
+      status: '매우 신뢰',
+      votePercentage: 0,
     },
     {
-      issueId: 3,
-      issueOrder: '세 번째 보도',
-      trust: 50,
-      doubt: 50,
+      status: '약간 신뢰',
+      votePercentage: 0,
     },
     {
-      issueId: 4,
-      issueOrder: '네 번째 보도',
-      trust: 10,
-      doubt: 90,
+      status: '약간 의심',
+      votePercentage: 0,
     },
   ],
 };

--- a/src/features/remakeissue/constants/formatDate.ts
+++ b/src/features/remakeissue/constants/formatDate.ts
@@ -10,3 +10,11 @@ export const formatDate = (dateString: string) => {
   // \s*는 0개 이상의 공백 문자를 의미함
   return formattedDate.replace(/(\d{4})년\s*(\d{2})월\s*(\d{2})일/, '$1.$2.$3');
 };
+
+export const formatMMDD = (dateString: string) => {
+  const date = new Date(dateString);
+  const month = (date.getMonth() + 1).toString().padStart(2, '0');
+  const day = date.getDate().toString().padStart(2, '0');
+
+  return month + '.' + day;
+};

--- a/src/features/remakeissue/constants/formatDate.ts
+++ b/src/features/remakeissue/constants/formatDate.ts
@@ -6,7 +6,7 @@ export const formatDate = (dateString: string) => {
 
   return `${year}.${month}.${day}`;
 };
-export const formatMMDD = (dateString: string) => {
+export const formatDateMMDD = (dateString: string) => {
   const date = new Date(dateString);
   const month = (date.getMonth() + 1).toString().padStart(2, '0');
   const day = date.getDate().toString().padStart(2, '0');

--- a/src/features/remakeissue/constants/formatDate.ts
+++ b/src/features/remakeissue/constants/formatDate.ts
@@ -1,16 +1,11 @@
 export const formatDate = (dateString: string) => {
   const date = new Date(dateString);
-  const formattedDate = new Intl.DateTimeFormat('ko-KR', {
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-  }).format(date);
+  const year = date.getFullYear().toString();
+  const month = (date.getMonth() + 1).toString().padStart(2, '0');
+  const day = date.getDate().toString().padStart(2, '0');
 
-  // '년', '월', '일' 문자와 사이의 공백을 고려하여 제거하고, 필요한 위치에 '.' 추가
-  // \s*는 0개 이상의 공백 문자를 의미함
-  return formattedDate.replace(/(\d{4})년\s*(\d{2})월\s*(\d{2})일/, '$1.$2.$3');
+  return `${year}.${month}.${day}`;
 };
-
 export const formatMMDD = (dateString: string) => {
   const date = new Date(dateString);
   const month = (date.getMonth() + 1).toString().padStart(2, '0');

--- a/src/features/totalvote/components/BarGraph.tsx
+++ b/src/features/totalvote/components/BarGraph.tsx
@@ -2,13 +2,13 @@ import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import Svg from 'react-native-svg';
 import { Rect, Line, Text as SvgText } from 'react-native-svg';
-import { TotalTrustVoteData } from '../../../dummy/TotalVotedDataDummy';
 import fontFamily from '../../../shared/styles/fontFamily';
 import { WINDOW_WIDTH } from '../../../shared/constants/display';
 import theme from '../../../shared/styles/theme';
+import { IntegratedResult } from '../types/integratedResult';
 
 interface BarGraphProps {
-  data: TotalTrustVoteData;
+  data: IntegratedResult;
 }
 
 const BarGraph = ({ data }: BarGraphProps) => {
@@ -50,9 +50,9 @@ const BarGraph = ({ data }: BarGraphProps) => {
             </SvgText>
           </React.Fragment>
         ))}
-        {data.voteRankings.map((item, index) => {
-          const trustHeight = (item.trust / 100) * barHeight;
-          const doubtHeight = (item.doubt / 100) * barHeight;
+        {data.voteResults.map((item, index) => {
+          const trustHeight = (item.trustRate / 100) * barHeight;
+          const doubtHeight = (item.doubtRate / 100) * barHeight;
 
           return (
             <React.Fragment key={index}>
@@ -90,7 +90,7 @@ const BarGraph = ({ data }: BarGraphProps) => {
                 fill={theme.color.gray6}
                 textAnchor="middle"
               >
-                {item.issueOrder}
+                첫 번째 보도
               </SvgText>
             </React.Fragment>
           );

--- a/src/features/totalvote/components/TimeLine.tsx
+++ b/src/features/totalvote/components/TimeLine.tsx
@@ -15,7 +15,7 @@ import { LinearGradient } from 'expo-linear-gradient';
 import { WithLocalSvg } from 'react-native-svg/css';
 import SeeOriginalSvg from '../../../assets/icon/seeOriginal.svg';
 import { getTimeLineIssues } from '../remotes/getTimeLineIssues';
-import { formatMMDD } from '../../remakeissue/constants/formatDate';
+import { formatDateMMDD } from '../../remakeissue/constants/formatDate';
 import { getNewsReportOrdinalInKorean } from '../../../shared/functions/getNewsReportOrdinalInKorean';
 
 interface TimeLineProps {
@@ -54,7 +54,7 @@ const TimeLine = ({ id }: TimeLineProps) => {
       {timeLineIssues.map((issue) => (
         <View key={issue.id} style={styles.issueContainer}>
           <View style={styles.timeContainer}>
-            <Text style={styles.dateText}>{formatMMDD(issue.createdAt)}</Text>
+            <Text style={styles.dateText}>{formatDateMMDD(issue.createdAt)}</Text>
             <View style={styles.dotLine}></View>
           </View>
           <LinearGradient

--- a/src/features/totalvote/components/TimeLine.tsx
+++ b/src/features/totalvote/components/TimeLine.tsx
@@ -15,8 +15,8 @@ import { LinearGradient } from 'expo-linear-gradient';
 import { WithLocalSvg } from 'react-native-svg/css';
 import SeeOriginalSvg from '../../../assets/icon/seeOriginal.svg';
 import { getTimeLineIssues } from '../remotes/getTimeLineIssues';
-import { formatDate, formatMMDD, formatMonthDay } from "../../remakeissue/constants/formatDate";
-import { getNewsReportOrdinalInKorean } from "../../../shared/functions/getNewsReportOrdinalInKorean";
+import { formatMMDD } from '../../remakeissue/constants/formatDate';
+import { getNewsReportOrdinalInKorean } from '../../../shared/functions/getNewsReportOrdinalInKorean';
 
 interface TimeLineProps {
   id: number;

--- a/src/features/totalvote/components/TimeLine.tsx
+++ b/src/features/totalvote/components/TimeLine.tsx
@@ -1,4 +1,3 @@
-import { getFollowUpIssueByIdVotePage } from '../../vote/remotes/getFollowUpIssue';
 import useFetch from '../../../shared/hooks/useFetch';
 import React, { useEffect } from 'react';
 import {
@@ -15,18 +14,16 @@ import GlobalTextStyles from '../../../shared/styles/GlobalTextStyles';
 import { LinearGradient } from 'expo-linear-gradient';
 import { WithLocalSvg } from 'react-native-svg/css';
 import SeeOriginalSvg from '../../../assets/icon/seeOriginal.svg';
+import { getTimeLineIssues } from '../remotes/getTimeLineIssues';
+import { formatDate, formatMMDD, formatMonthDay } from "../../remakeissue/constants/formatDate";
+import { getNewsReportOrdinalInKorean } from "../../../shared/functions/getNewsReportOrdinalInKorean";
 
 interface TimeLineProps {
   id: number;
 }
 const TimeLine = ({ id }: TimeLineProps) => {
-  const fetchFollowUpIssueTotalPage = () => getFollowUpIssueByIdVotePage(id);
-  const {
-    data: followUpIssuesTotalVotePage,
-    isLoading,
-    error,
-    fetchData,
-  } = useFetch(fetchFollowUpIssueTotalPage, false);
+  const fetchIssueTimeLine = () => getTimeLineIssues(id);
+  const { data: timeLineIssues, isLoading, error, fetchData } = useFetch(fetchIssueTimeLine, false);
 
   useEffect(() => {
     void fetchData();
@@ -48,134 +45,54 @@ const TimeLine = ({ id }: TimeLineProps) => {
     );
   }
 
-  if (!followUpIssuesTotalVotePage || followUpIssuesTotalVotePage.followUpIssues.length === 0) {
-    return (
-      <View style={styles.container}>
-        <View style={styles.issueContainer}>
-          <View style={styles.timeContainer}>
-            <Text style={styles.dateText}>10.25</Text>
-            <View style={styles.dotLine}></View>
-          </View>
-          <LinearGradient
-            start={{ x: 1, y: 1 }}
-            end={{ x: 0, y: 0 }}
-            colors={theme.gradient.gradient1}
-            style={styles.boxLine}
-          >
-            <LinearGradient
-              start={{ x: 0, y: 1 }}
-              end={{ x: 1, y: 1 }}
-              colors={theme.gradient.gradient2}
-              style={styles.issueBox}
-            >
-              <View style={styles.issueContextContainer}>
-                <View style={styles.tagContainer}>
-                  <View style={styles.tag}>
-                    <Text style={styles.tagText}>첫 보도</Text>
-                  </View>
-                  <TouchableOpacity onPress={() => {}}>
-                    <WithLocalSvg
-                      width={79}
-                      height={30}
-                      asset={SeeOriginalSvg as ImageSourcePropType}
-                    />
-                  </TouchableOpacity>
-                </View>
-                <View style={styles.textContainer}>
-                  <Text style={styles.boxTitle}>빅뱅 지드래곤도 마약 혐의로 입건</Text>
-                  <Text style={styles.boxContext}>
-                    25일 법조계와 경찰에 따르면 인천경찰청 마약범죄...
-                  </Text>
-                </View>
-              </View>
-            </LinearGradient>
-          </LinearGradient>
-        </View>
-        <View style={styles.issueContainer}>
-          <View style={styles.timeContainer}>
-            <Text style={styles.dateText}>10.25</Text>
-            <View style={styles.dotLine}></View>
-          </View>
-          <LinearGradient
-            start={{ x: 1, y: 1 }}
-            end={{ x: 0, y: 0 }}
-            colors={theme.gradient.gradient1}
-            style={styles.boxLine}
-          >
-            <LinearGradient
-              start={{ x: 0, y: 1 }}
-              end={{ x: 1, y: 1 }}
-              colors={theme.gradient.gradient2}
-              style={styles.issueBox}
-            >
-              <View style={styles.issueContextContainer}>
-                <View style={styles.tagContainer}>
-                  <View style={styles.tag}>
-                    <Text style={styles.tagText}>두 번째 보도</Text>
-                  </View>
-                  <TouchableOpacity onPress={() => {}}>
-                    <WithLocalSvg
-                      width={79}
-                      height={30}
-                      asset={SeeOriginalSvg as ImageSourcePropType}
-                    />
-                  </TouchableOpacity>
-                </View>
-                <View style={styles.textContainer}>
-                  <Text style={styles.boxTitle}>빅뱅 지드래곤도 마약 혐의로 입건</Text>
-                  <Text style={styles.boxContext}>
-                    25일 법조계와 경찰에 따르면 인천경찰청 마약범죄...
-                  </Text>
-                </View>
-              </View>
-            </LinearGradient>
-          </LinearGradient>
-        </View>
-        <View style={styles.issueContainer}>
-          <View style={styles.timeContainer}>
-            <Text style={styles.dateText}>10.25</Text>
-            <View style={styles.dotLine}></View>
-          </View>
-          <LinearGradient
-            start={{ x: 1, y: 1 }}
-            end={{ x: 0, y: 0 }}
-            colors={theme.gradient.gradient1}
-            style={styles.boxLine}
-          >
-            <LinearGradient
-              start={{ x: 0, y: 1 }}
-              end={{ x: 1, y: 1 }}
-              colors={theme.gradient.gradient2}
-              style={styles.issueBox}
-            >
-              <View style={styles.issueContextContainer}>
-                <View style={styles.tagContainer}>
-                  <View style={styles.tag}>
-                    <Text style={styles.tagText}>세 번째 보도</Text>
-                  </View>
-                  <TouchableOpacity onPress={() => {}}>
-                    <WithLocalSvg
-                      width={79}
-                      height={30}
-                      asset={SeeOriginalSvg as ImageSourcePropType}
-                    />
-                  </TouchableOpacity>
-                </View>
-                <View style={styles.textContainer}>
-                  <Text style={styles.boxTitle}>빅뱅 지드래곤도 마약 혐의로 입건</Text>
-                  <Text style={styles.boxContext}>
-                    25일 법조계와 경찰에 따르면 인천경찰청 마약범죄...
-                  </Text>
-                </View>
-              </View>
-            </LinearGradient>
-          </LinearGradient>
-        </View>
-      </View>
-    );
+  if (!timeLineIssues) {
+    return <View style={styles.container} />;
   }
 
-  return <View style={styles.container} />;
+  return (
+    <View style={styles.container}>
+      {timeLineIssues.map((issue) => (
+        <View key={issue.id} style={styles.issueContainer}>
+          <View style={styles.timeContainer}>
+            <Text style={styles.dateText}>{formatMMDD(issue.createdAt)}</Text>
+            <View style={styles.dotLine}></View>
+          </View>
+          <LinearGradient
+            start={{ x: 1, y: 1 }}
+            end={{ x: 0, y: 0 }}
+            colors={theme.gradient.gradient1}
+            style={styles.boxLine}
+          >
+            <LinearGradient
+              start={{ x: 0, y: 1 }}
+              end={{ x: 1, y: 1 }}
+              colors={theme.gradient.gradient2}
+              style={styles.issueBox}
+            >
+              <View style={styles.issueContextContainer}>
+                <View style={styles.tagContainer}>
+                  <View style={styles.tag}>
+                    <Text style={styles.tagText}>{getNewsReportOrdinalInKorean(issue.id)}</Text>
+                  </View>
+                  <TouchableOpacity onPress={() => {}}>
+                    <WithLocalSvg
+                      width={79}
+                      height={30}
+                      asset={SeeOriginalSvg as ImageSourcePropType}
+                    />
+                  </TouchableOpacity>
+                </View>
+                <View style={styles.textContainer}>
+                  <Text style={styles.boxTitle}>{issue.title}</Text>
+                  <Text style={styles.boxContext}>작업이 필요합니다.</Text>
+                </View>
+              </View>
+            </LinearGradient>
+          </LinearGradient>
+        </View>
+      ))}
+    </View>
+  );
 };
 
 const styles = StyleSheet.create({

--- a/src/features/totalvote/components/TotalVoteChartContainer.tsx
+++ b/src/features/totalvote/components/TotalVoteChartContainer.tsx
@@ -3,11 +3,11 @@ import { StyleSheet, Text, View } from 'react-native';
 import theme from '../../../shared/styles/theme';
 import fontFamily from '../../../shared/styles/fontFamily';
 import { formatNumber } from '../../../shared/utils/formatNumber';
-import { TotalTrustVoteData } from '../../../dummy/TotalVotedDataDummy';
 import BarGraph from './BarGraph';
+import { IntegratedResult } from '../types/integratedResult';
 
 interface VoteBubbleChartProps {
-  data: TotalTrustVoteData;
+  data: IntegratedResult;
 }
 const TotalVoteChartContainer = ({ data }: VoteBubbleChartProps) => {
   return (
@@ -15,7 +15,7 @@ const TotalVoteChartContainer = ({ data }: VoteBubbleChartProps) => {
       <View style={styles.topContainer}>
         <Text style={styles.voteResultText}>최종 투표 결과</Text>
         <Text style={styles.mostVotedText}>
-          {data.mostVotedStatus} {formatNumber(data.mostVotedCount)}표
+          {data.mostVoted} {formatNumber(data.mostVotedCount)}표
         </Text>
         <Text style={styles.totalVotedText}>총 투표 수: {formatNumber(data.totalVoteCount)}표</Text>
       </View>

--- a/src/features/totalvote/remotes/getIntegratedResult.ts
+++ b/src/features/totalvote/remotes/getIntegratedResult.ts
@@ -1,7 +1,7 @@
 import { client } from '../../../shared/remotes/axios';
-import { IntegratedResult } from "../types/integratedResult";
+import { IntegratedResult } from '../types/integratedResult';
 
 export const getIntegratedResult = async (id: number) => {
-  const { data } = await client.get<IntegratedResult>(`/reprocessed-issue/${id}/integrated-result`);
+  const { data } = await client.get<IntegratedResult>(`/issue/${id}/integrated-result`);
   return data;
 };

--- a/src/features/totalvote/remotes/getIntegratedResult.ts
+++ b/src/features/totalvote/remotes/getIntegratedResult.ts
@@ -1,0 +1,7 @@
+import { client } from '../../../shared/remotes/axios';
+import { IntegratedResult } from "../types/integratedResult";
+
+export const getIntegratedResult = async (id: number) => {
+  const { data } = await client.get<IntegratedResult>(`/reprocessed-issue/${id}/integrated-result`);
+  return data;
+};

--- a/src/features/totalvote/remotes/getTimeLineIssues.ts
+++ b/src/features/totalvote/remotes/getTimeLineIssues.ts
@@ -1,0 +1,7 @@
+import { client } from '../../../shared/remotes/axios';
+import { TimeLineInfo } from '../types/timeLine';
+
+export const getTimeLineIssues = async (id: number) => {
+  const { data } = await client.get<TimeLineInfo[]>(`/issue/${id}/time-line`);
+  return data;
+};

--- a/src/features/totalvote/types/integratedResult.ts
+++ b/src/features/totalvote/types/integratedResult.ts
@@ -1,0 +1,14 @@
+import { VoteData } from "../../vote/types/bubbleChartData";
+
+export interface IntegratedResult {
+  mostVoted: string;
+  mostVotedCount: number;
+  totalVoteCount: number;
+  voteResults: IntegratedVoteResult[];
+  voteRankings: VoteData[];
+}
+
+export interface IntegratedVoteResult {
+  trustRate: number;
+  doubtRate: number;
+}

--- a/src/features/totalvote/types/integratedResult.ts
+++ b/src/features/totalvote/types/integratedResult.ts
@@ -1,4 +1,4 @@
-import { VoteData } from "../../vote/types/bubbleChartData";
+import { VoteData } from '../../vote/types/bubbleChartData';
 
 export interface IntegratedResult {
   mostVoted: string;

--- a/src/features/totalvote/types/timeLine.ts
+++ b/src/features/totalvote/types/timeLine.ts
@@ -1,0 +1,6 @@
+export interface TimeLineInfo {
+  issueType: string;
+  id: number;
+  title: string;
+  createdAt: string;
+}

--- a/src/features/vote/components/FollowUpIssueSlider.tsx
+++ b/src/features/vote/components/FollowUpIssueSlider.tsx
@@ -1,12 +1,19 @@
 import React, { useEffect } from 'react';
-import { ActivityIndicator, FlatList, StyleSheet, Text, View } from 'react-native';
+import {
+  ActivityIndicator,
+  FlatList,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
 import fontFamily from '../../../shared/styles/fontFamily';
 import theme from '../../../shared/styles/theme';
 import FollowUpIssueCardGradient from '../../../shared/components/FollowUpIssue/FollowUpIssueCardGradient';
 import { getFollowUpIssueByIdVotePage } from '../remotes/getFollowUpIssue';
 import useFetch from '../../../shared/hooks/useFetch';
 import GlobalTextStyles from '../../../shared/styles/GlobalTextStyles';
-import followUpIssueDummy from '../../../dummy/FollowUpIssueDummy';
+import EmptyScreen from '../../../shared/components/Opinion/EmptyScreen';
 
 interface FollowUpIssueSliderProps {
   id: number;
@@ -44,13 +51,11 @@ const FollowUpIssueSlider = ({ id }: FollowUpIssueSliderProps) => {
     return (
       <View style={styles.container}>
         <Text style={styles.titleText}>후속 이슈</Text>
-        <FlatList
-          horizontal
-          showsHorizontalScrollIndicator={false}
-          contentContainerStyle={styles.cardContainer}
-          data={followUpIssueDummy}
-          renderItem={({ item }) => <FollowUpIssueCardGradient item={item} />}
-        ></FlatList>
+        <View style={{ marginTop: 12 }} />
+        <EmptyScreen text={'후속 이슈가 존재하지 않습니다.'} />
+        <TouchableOpacity style={styles.alertButton} onPress={() => {}}>
+          <Text style={styles.alertButtonText}>이슈 알림 받기</Text>
+        </TouchableOpacity>
       </View>
     );
   }
@@ -95,6 +100,27 @@ const styles = StyleSheet.create({
     letterSpacing: -0.51,
     color: theme.color.white,
     width: '100%',
+  },
+  alertButton: {
+    display: 'flex',
+    borderRadius: 10,
+    width: 160,
+    height: 50,
+    justifyContent: 'center',
+    alignItems: 'center',
+    flexShrink: 0,
+    backgroundColor: theme.color.gray3,
+    marginTop: 32,
+  },
+  alertButtonText: {
+    fontFamily: fontFamily.pretendard.bold,
+    fontSize: 17,
+    fontStyle: 'normal',
+    fontWeight: '700',
+    lineHeight: 25.5,
+    letterSpacing: -0.51,
+    color: theme.color.white,
+    textAlign: 'center',
   },
 });
 export default FollowUpIssueSlider;

--- a/src/features/vote/components/RelatedIssues.tsx
+++ b/src/features/vote/components/RelatedIssues.tsx
@@ -2,11 +2,12 @@ import React, { useEffect } from 'react';
 import { ActivityIndicator, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import fontFamily from '../../../shared/styles/fontFamily';
 import theme from '../../../shared/styles/theme';
-import followUpIssueDummy from '../../../dummy/FollowUpIssueDummy';
 import { formatDate } from '../../remakeissue/constants/formatDate';
 import { WINDOW_WIDTH } from '../../../shared/constants/display';
 import { getRelatedIssuesById } from '../remotes/getRecommendIssuesByCategory';
 import useFetch from '../../../shared/hooks/useFetch';
+import GlobalTextStyles from '../../../shared/styles/GlobalTextStyles';
+import EmptyScreen from '../../../shared/components/Opinion/EmptyScreen';
 
 interface RecommendIssuesProps {
   id: number;
@@ -35,25 +36,8 @@ const RelatedIssues = ({ id }: RecommendIssuesProps) => {
 
   if (error) {
     return (
-      // <View style={styles.container}>
-      //   <Text style={GlobalTextStyles.NormalText17}>ERROR</Text>
-      // </View>
       <View style={styles.container}>
-        <Text style={styles.titleText}>이 뉴스도 한번 봐보세요</Text>
-        {followUpIssueDummy.map((item, index) => (
-          <TouchableOpacity key={index} style={styles.card} onPress={() => {}}>
-            <View style={styles.leftContainer}>
-              <Text style={styles.cardTitleText}>{item.title}</Text>
-              <View style={styles.titleUnderContainer}>
-                <View style={styles.tagBox}>
-                  <Text style={styles.tagText}>국제</Text>
-                </View>
-                <Text style={styles.dateText}>{formatDate(item.createdAt)}</Text>
-              </View>
-            </View>
-            <View style={styles.cardImage} />
-          </TouchableOpacity>
-        ))}
+        <Text style={GlobalTextStyles.NormalText17}>ERROR</Text>
       </View>
     );
   }
@@ -62,20 +46,7 @@ const RelatedIssues = ({ id }: RecommendIssuesProps) => {
     return (
       <View style={styles.container}>
         <Text style={styles.titleText}>이 뉴스도 한번 봐보세요</Text>
-        {followUpIssueDummy.map((item, index) => (
-          <TouchableOpacity key={index} style={styles.card} onPress={() => {}}>
-            <View style={styles.leftContainer}>
-              <Text style={styles.cardTitleText}>{item.title}</Text>
-              <View style={styles.titleUnderContainer}>
-                <View style={styles.tagBox}>
-                  <Text style={styles.tagText}>국제</Text>
-                </View>
-                <Text style={styles.dateText}>{formatDate(item.createdAt)}</Text>
-              </View>
-            </View>
-            <View style={styles.cardImage} />
-          </TouchableOpacity>
-        ))}
+        <EmptyScreen text={'등록된 추천 이슈가 없습니다.'} />
       </View>
     );
   }

--- a/src/features/vote/components/VoteRankContainer.tsx
+++ b/src/features/vote/components/VoteRankContainer.tsx
@@ -3,17 +3,17 @@ import { StyleSheet, View, Text, ImageSourcePropType } from 'react-native';
 import { WithLocalSvg } from 'react-native-svg/css';
 import theme from '../../../shared/styles/theme';
 import fontFamily from '../../../shared/styles/fontFamily';
-import { TrustVoteData } from '../types/bubbleChartData';
+import { VoteData } from '../types/bubbleChartData';
 import { getRankColor, getRankIcon } from '../constants/rankConstants';
 
 interface VoteRankContainerProps {
-  data: TrustVoteData;
+  data: VoteData[];
 }
 
 const VoteRankContainer = ({ data }: VoteRankContainerProps) => {
   return (
     <View style={styles.container}>
-      {data.voteRankings.map((item, index) => (
+      {data.map((item, index) => (
         <View key={index} style={styles.item}>
           <View style={styles.leftContainer}>
             <Text style={styles.rank}>{index + 1}</Text>

--- a/src/pages/TotalVoteResultPage.tsx
+++ b/src/pages/TotalVoteResultPage.tsx
@@ -19,16 +19,14 @@ import MainArrowLeftSvg from '../assets/icon/mainarrowLeft.svg';
 import BookMarkSvg from '../assets/icon/bookmark.svg';
 import { WINDOW_WIDTH } from '../shared/constants/display';
 import fontFamily from '../shared/styles/fontFamily';
-import { TotalVotedDataDummy } from '../dummy/TotalVotedDataDummy';
 import TotalVoteChartContainer from '../features/totalvote/components/TotalVoteChartContainer';
 import VoteRankContainer from '../features/vote/components/VoteRankContainer';
-import { VotedDataDummy } from '../dummy/VotedDataDummy';
 import RelatedIssues from '../features/vote/components/RelatedIssues';
 import TimeLine from '../features/totalvote/components/TimeLine';
 import useFetch from '../shared/hooks/useFetch';
 import { getIntegratedResult } from '../features/totalvote/remotes/getIntegratedResult';
 import GlobalTextStyles from '../shared/styles/GlobalTextStyles';
-import EmptyScreen from "../shared/components/Opinion/EmptyScreen";
+import EmptyScreen from '../shared/components/Opinion/EmptyScreen';
 const TotalVoteResultPage = () => {
   const navigation = useNavigation<StackNavigationProp<RootStackParamList>>();
   type ScreenRouteProp = RouteProp<RootStackParamList, 'TotalVoteResultPage'>;
@@ -45,7 +43,6 @@ const TotalVoteResultPage = () => {
 
   useEffect(() => {
     void fetchData();
-    console.log(integratedVoteData);
   }, []);
 
   if (isLoading) {

--- a/src/pages/TotalVoteResultPage.tsx
+++ b/src/pages/TotalVoteResultPage.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import {
+  ActivityIndicator,
   Dimensions,
   ImageSourcePropType,
   ScrollView,
@@ -24,11 +25,52 @@ import VoteRankContainer from '../features/vote/components/VoteRankContainer';
 import { VotedDataDummy } from '../dummy/VotedDataDummy';
 import RelatedIssues from '../features/vote/components/RelatedIssues';
 import TimeLine from '../features/totalvote/components/TimeLine';
+import useFetch from '../shared/hooks/useFetch';
+import { getIntegratedResult } from '../features/totalvote/remotes/getIntegratedResult';
+import GlobalTextStyles from '../shared/styles/GlobalTextStyles';
+import EmptyScreen from "../shared/components/Opinion/EmptyScreen";
 const TotalVoteResultPage = () => {
   const navigation = useNavigation<StackNavigationProp<RootStackParamList>>();
   type ScreenRouteProp = RouteProp<RootStackParamList, 'TotalVoteResultPage'>;
   const route = useRoute<ScreenRouteProp>();
   const id: number = route.params.id;
+
+  const fetchReprocessedIssueIntegratedVote = () => getIntegratedResult(id);
+  const {
+    data: integratedVoteData,
+    isLoading,
+    error,
+    fetchData,
+  } = useFetch(fetchReprocessedIssueIntegratedVote, false);
+
+  useEffect(() => {
+    void fetchData();
+    console.log(integratedVoteData);
+  }, []);
+
+  if (isLoading) {
+    return (
+      <View style={styles.container}>
+        <ActivityIndicator size="large" style={styles.activityIndicator} />
+      </View>
+    );
+  }
+
+  if (error) {
+    return (
+      <View style={styles.container}>
+        <Text style={GlobalTextStyles.NormalText17}>ERROR</Text>
+      </View>
+    );
+  }
+
+  if (!integratedVoteData) {
+    return (
+      <View style={styles.container}>
+        <EmptyScreen text={'통합 투표 화면이 없습니다.'} />
+      </View>
+    );
+  }
 
   return (
     <View style={styles.container}>
@@ -48,12 +90,12 @@ const TotalVoteResultPage = () => {
         }
       />
       <ScrollView style={styles.scrollViewStyle}>
-        <TotalVoteChartContainer data={TotalVotedDataDummy} />
+        <TotalVoteChartContainer data={integratedVoteData} />
         <View style={styles.underChartContainer}>
           <View style={styles.rankContainer}>
             <Text style={styles.rankTitleText}>전체 투표 순위</Text>
           </View>
-          <VoteRankContainer data={VotedDataDummy} />
+          <VoteRankContainer data={integratedVoteData.voteRankings} />
         </View>
         <View style={styles.divideLine} />
         <View style={styles.timeLineContainer}>

--- a/src/pages/VoteResultPage.tsx
+++ b/src/pages/VoteResultPage.tsx
@@ -100,7 +100,7 @@ const VoteResultPage = () => {
           <View style={styles.rankContainer}>
             <Text style={styles.rankTitleText}>전체 투표 순위</Text>
           </View>
-          <VoteRankContainer data={voteData} />
+          <VoteRankContainer data={voteData.voteRankings} />
         </View>
         <View style={styles.divideLine} />
         <TopOpinionSlider id={id} />

--- a/src/shared/components/FollowUpIssue/FollowUpIssueCardGradient.tsx
+++ b/src/shared/components/FollowUpIssue/FollowUpIssueCardGradient.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
-import { FollowUpIssue } from '../../types/news';
 import theme from '../../../shared/styles/theme';
 import { LinearGradient } from 'expo-linear-gradient';
 import { formatDate } from '../../../features/remakeissue/constants/formatDate';
 import fontFamily from '../../styles/fontFamily';
 import { FollowUpIssueVotePageItem } from '../../../features/vote/types/followUpIssueVotePage';
+import { getNewsReportOrdinalInKorean } from '../../functions/getNewsReportOrdinalInKorean';
 
 interface FollowUpIssueCardGradientProps {
-  item: FollowUpIssueVotePageItem | FollowUpIssue;
+  item: FollowUpIssueVotePageItem;
 }
 
 const FollowUpIssueCardGradient = ({ item }: FollowUpIssueCardGradientProps) => {
@@ -33,7 +33,7 @@ const FollowUpIssueCardGradient = ({ item }: FollowUpIssueCardGradientProps) => 
             </Text>
             <View style={styles.titleUnderContainer}>
               <View style={styles.tagBox}>
-                <Text style={styles.tagText}>첫 보도</Text>
+                <Text style={styles.tagText}>{getNewsReportOrdinalInKorean(item.id)}</Text>
               </View>
               <Text style={styles.dateText}>{formatDate(item.createdAt)}</Text>
             </View>

--- a/src/shared/functions/getNewsReportOrdinalInKorean.ts
+++ b/src/shared/functions/getNewsReportOrdinalInKorean.ts
@@ -1,16 +1,6 @@
+import { numberToKoreanOrdinal } from './numberToKoreanOrdinal';
+
 export function getNewsReportOrdinalInKorean(num: number): string {
-  switch (num) {
-    case 1:
-      return '첫 보도';
-    case 2:
-      return '두 번째 보도';
-    case 3:
-      return '세 번째 보도';
-    case 4:
-      return '네 번째 보도';
-    case 5:
-      return '다섯 번째 보도';
-    default:
-      return '해당 사항 없음';
-  }
+  if (num == 1) return '첫 보도';
+  else return numberToKoreanOrdinal(num) + '보도';
 }

--- a/src/shared/functions/getNewsReportOrdinalInKorean.ts
+++ b/src/shared/functions/getNewsReportOrdinalInKorean.ts
@@ -1,0 +1,16 @@
+export function getNewsReportOrdinalInKorean(num: number): string {
+  switch (num) {
+    case 1:
+      return '첫 보도';
+    case 2:
+      return '두 번째 보도';
+    case 3:
+      return '세 번째 보도';
+    case 4:
+      return '네 번째 보도';
+    case 5:
+      return '다섯 번째 보도';
+    default:
+      return '해당 사항 없음';
+  }
+}

--- a/src/shared/functions/numberToKoreanOrdinal.ts
+++ b/src/shared/functions/numberToKoreanOrdinal.ts
@@ -1,0 +1,27 @@
+export function numberToKoreanOrdinal(num: number) {
+  const units = ['', '한', '두', '세', '네', '다섯', '여섯', '일곱', '여덟', '아홉'];
+  const tens = ['', '열', '스물', '서른', '마흔', '쉰', '예순', '일흔', '여든', '아흔'];
+  const suffix = ' 번째';
+
+  if (num === 100) {
+    return '백 번째';
+  }
+
+  if (num == 1) {
+    return '첫 번째';
+  }
+
+  const tenPart = Math.floor(num / 10);
+  const unitPart = num % 10;
+
+  let koreanNumber = '';
+
+  if (tenPart > 0) {
+    koreanNumber += tens[tenPart];
+  }
+  if (unitPart > 0) {
+    koreanNumber += units[unitPart];
+  }
+
+  return koreanNumber + suffix;
+}


### PR DESCRIPTION
## 💬리뷰 참고사항

> API 연동은, pages/TotalVoteResultPage, VoteResultPage 모두 진행하였습니다.

- 후속 이슈 슬라이더는, api 연동을 완료한 상태이나, 타임라인 컴포넌트와 같이, 재가공 이슈까지 포함하여 제공해야한다는 내용을 고려하여 이후에 수정이 진행될 것 같습니다.
- 통합 투표 페이지는, 후속 이슈가 존재하지 않으면 넘어가지 않도록 기획서에 정의되어있으나, 후속 이슈 컨텐츠가 아직 제작되어있지 않았고, 넘어가지 않을 때 보여지는 팝업 디자인이 제작되어있지 않았기 때문에 우선 페이지는 이동이 가능한 상태입니다.

- src/shared/functions/getNewsReportOrdinalInKorean.ts 에 있는 뉴스보도의 순서를 반환하는 함수에 대해서 피드백을 받고 싶습니다. 숫자를 받았을 때, '첫 보도, 두 번째 보도'와 같은 반환값을 각각 일일이 작성하게 되었는데, 이슈 번호에 맞춰서 'N번째 보도'를 반환하는 함수를 작성하려면 어떤 방식이 좋을지 고민이 있습니다.

## #️⃣연관된 이슈

> 연관된 이슈 번호를 모두 작성

closes #91 