### PR TITLE
Refactor/#106 잘못된 키워드 수정 및 마크다운 '강조' 스타일 추가

### DIFF
--- a/src/features/remakeissue/components/ReprocessedIssueContentsSlider.tsx
+++ b/src/features/remakeissue/components/ReprocessedIssueContentsSlider.tsx
@@ -51,7 +51,7 @@ const markdownStyles = StyleSheet.create({
     fontFamily: fontFamily.pretendard.medium,
     fontStyle: 'normal',
     fontSize: 14,
-    fontWeight: '700',
+    fontWeight: '500',
     lineHeight: 21,
     letterSpacing: -0.42,
   },

--- a/src/features/remakeissue/components/ReprocessedIssueContentsSlider.tsx
+++ b/src/features/remakeissue/components/ReprocessedIssueContentsSlider.tsx
@@ -69,6 +69,9 @@ const markdownStyles = StyleSheet.create({
     marginTop: 15,
     textAlign: 'left',
   },
+  strong: {
+    fontFamily: fontFamily.pretendard.bold,
+  },
 });
 
 const styles = StyleSheet.create({

--- a/src/features/remakeissue/constants/reliabilty.ts
+++ b/src/features/remakeissue/constants/reliabilty.ts
@@ -1,6 +1,6 @@
 export const reliabilityText = [
-  { id: 1, text: '완전 신뢰', value: 'HIGHLY_TRUSTED' },
-  { id: 2, text: '조금 신뢰', value: 'SOMEWHAT_TRUSTED' },
-  { id: 3, text: '조금 의심', value: 'SOMEWHAT_DISTRUSTED' },
-  { id: 4, text: '완전 의심', value: 'HIGHLY_DISTRUSTED' },
+  { id: 1, text: '매우 신뢰', value: 'HIGHLY_TRUSTED' },
+  { id: 2, text: '약간 신뢰', value: 'SOMEWHAT_TRUSTED' },
+  { id: 3, text: '약간 의심', value: 'SOMEWHAT_DISTRUSTED' },
+  { id: 4, text: '매우 의심', value: 'HIGHLY_DISTRUSTED' },
 ];

--- a/src/pages/OpinionPinPage.tsx
+++ b/src/pages/OpinionPinPage.tsx
@@ -22,6 +22,8 @@ import useFetch from '../shared/hooks/useFetch';
 import GlobalTextStyles from '../shared/styles/GlobalTextStyles';
 import PageHeader from '../shared/components/PageHeader';
 import { WINDOW_WIDTH } from '../shared/constants/display';
+import Markdown from "react-native-markdown-display";
+import fontFamily from "../shared/styles/fontFamily";
 
 const OpinionPinPage = () => {
   const navigation = useNavigation<StackNavigationProp<RootStackParamList>>();
@@ -105,7 +107,9 @@ const OpinionPinPage = () => {
                   </View>
                 </View>
                 <View style={styles.sentenceContainer}>
-                  <Text style={styles.sentenceText}>{item.paragraph}</Text>
+                  <Markdown style={markdownStyles} key={item.id}>
+                    {item.paragraph}
+                  </Markdown>
                 </View>
               </TouchableOpacity>
             ))}
@@ -114,6 +118,22 @@ const OpinionPinPage = () => {
     </View>
   );
 };
+
+const markdownStyles = StyleSheet.create({
+  body: {
+    color: theme.color.white,
+    textAlign: 'justify',
+    fontSize: 14,
+    fontStyle: 'normal',
+    fontWeight: '700',
+    lineHeight: 21,
+    letterSpacing: -0.42,
+    fontFamily: fontFamily.pretendard.medium,
+  },
+  strong: {
+    fontFamily: fontFamily.pretendard.bold,
+  },
+});
 
 const styles = StyleSheet.create({
   container: {
@@ -169,6 +189,7 @@ const styles = StyleSheet.create({
     display: 'flex',
     flexDirection: 'row',
     alignItems: 'flex-start',
+    paddingHorizontal: 18,
     gap: 8,
   },
   pinContainer: {
@@ -178,7 +199,7 @@ const styles = StyleSheet.create({
   },
   sentenceContainer: {
     display: 'flex',
-    width: 314,
+    width: '100%',
   },
   sentenceText: {
     color: theme.color.white,
@@ -190,6 +211,7 @@ const styles = StyleSheet.create({
     letterSpacing: -0.42,
   },
   pin: {
+    marginTop: 12,
     width: 20,
     height: 20,
   },


### PR DESCRIPTION
## 💬리뷰 참고사항

![image](https://github.com/Neupinion/Neupinion-App/assets/71542970/d27f0437-1114-4880-9b78-3e22b8344262)

- 의견 핀 찍기 활동에서, 마크다운이 적용되지 않던 이슈를 해결했습니다.
- 의견 핀 찍기 활동에서, 마크다운 강조가 적용되지 않던 이슈를 해결했습니다.
- 재가공 이슈에서, 마크다운 강조가 적용되지 않던 이슈를 해결했습니다.

![image](https://github.com/Neupinion/Neupinion-App/assets/71542970/1fb89db9-d846-441a-9dd6-cc0e4692c974)
- 신뢰도 평가 키워드를 수정하여 추가하였습니다.

## #️⃣연관된 이슈

> 연관된 이슈 번호를 모두 작성

closes #106 #107 