### PR TITLE
feat: 메인페이지 워딩 변경 및  top5의 견 위치 수정

### DIFF
--- a/src/features/vote/components/TopOpinionSlider.tsx
+++ b/src/features/vote/components/TopOpinionSlider.tsx
@@ -52,7 +52,7 @@ const TopOpinionSlider = ({ id }: TopOpinionSliderProps) => {
 
   return (
     <View style={styles.container}>
-      <Text style={styles.titleText}>통합 베스트 Top 5 의견</Text>
+      {/*<Text style={styles.titleText}>통합 베스트 Top 5 의견</Text>*/}
       <FlatList
         horizontal
         showsHorizontalScrollIndicator={false}

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -59,23 +59,23 @@ const MainPage = () => {
             </View>
             <AfterIssueSlider afterNews={FollowUpIssueDummy} />
             <View style={styles.titleContainer}>
-              <Text style={GlobalTextStyles.NormalText17}>가짜뉴스 이슈(타이틀 변경 예정)</Text>
+              <Text style={GlobalTextStyles.NormalText17}>Hot한 입장 정리 모음</Text>
             </View>
             <FakeIssueSlider onClickIssue={onClickReprocessedIssue} fakeNews={reprocessedIssue} />
-            <View style={styles.titleContainer}>
-              <Text style={GlobalTextStyles.NormalText17}>카테고리1</Text>
-              <TouchableOpacity style={styles.svgStyle} onPress={() => {}}>
-                <WithLocalSvg width={14} height={14} asset={MainArrowSvg as ImageSourcePropType} />
-              </TouchableOpacity>
-            </View>
-            <CategorySlider categoryIssues={reprocessedIssue} />
-            <View style={styles.titleContainer}>
-              <Text style={GlobalTextStyles.NormalText17}>카테고리2</Text>
-              <TouchableOpacity style={styles.svgStyle} onPress={() => {}}>
-                <WithLocalSvg width={14} height={14} asset={MainArrowSvg as ImageSourcePropType} />
-              </TouchableOpacity>
-            </View>
-            <CategorySlider categoryIssues={reprocessedIssue} />
+            {/*<View style={styles.titleContainer}>*/}
+            {/*  <Text style={GlobalTextStyles.NormalText17}>카테고리1</Text>*/}
+            {/*  <TouchableOpacity style={styles.svgStyle} onPress={() => {}}>*/}
+            {/*    <WithLocalSvg width={14} height={14} asset={MainArrowSvg as ImageSourcePropType} />*/}
+            {/*  </TouchableOpacity>*/}
+            {/*</View>*/}
+            {/*<CategorySlider categoryIssues={reprocessedIssue} />*/}
+            {/*<View style={styles.titleContainer}>*/}
+            {/*  <Text style={GlobalTextStyles.NormalText17}>카테고리2</Text>*/}
+            {/*  <TouchableOpacity style={styles.svgStyle} onPress={() => {}}>*/}
+            {/*    <WithLocalSvg width={14} height={14} asset={MainArrowSvg as ImageSourcePropType} />*/}
+            {/*  </TouchableOpacity>*/}
+            {/*</View>*/}
+            {/*<CategorySlider categoryIssues={reprocessedIssue} />*/}
             <View style={styles.divideLine}></View>
             <View style={styles.titleContainer}>
               <Text style={GlobalTextStyles.NormalText17}>후속이슈</Text>

--- a/src/pages/OpinionMainPage.tsx
+++ b/src/pages/OpinionMainPage.tsx
@@ -37,79 +37,65 @@ const OpinionMainPage = () => {
   }, []);
   return (
     <ScrollView style={styles.container}>
-      <ScrollView>
-        {reprocessedIssue && (
-          <View style={{ marginTop: 32 }}>
-            <Text style={styles.titleText}>{reprocessedIssue.title}</Text>
-            <View style={styles.titleUnderContainer}>
-              <View style={{ flexDirection: 'row' }}>
-                <View style={styles.tagBox}>
-                  <Text style={styles.tagText}>{reprocessedIssue.category}</Text>
-                </View>
-                <Text style={styles.dateText}>{formatDate(reprocessedIssue.createdAt)}</Text>
+      {reprocessedIssue && (
+        <View style={{ marginTop: 32 }}>
+          <Text style={styles.titleText}>{reprocessedIssue.title}</Text>
+          <View style={styles.titleUnderContainer}>
+            <View style={{ flexDirection: 'row' }}>
+              <View style={styles.tagBox}>
+                <Text style={styles.tagText}>{reprocessedIssue.category}</Text>
               </View>
-              <TouchableOpacity style={styles.headerSvg} onPress={() => {}}>
-                <WithLocalSvg
-                  width={79}
-                  height={30}
-                  asset={SeeOriginalSvg as ImageSourcePropType}
-                />
-              </TouchableOpacity>
+              <Text style={styles.dateText}>{formatDate(reprocessedIssue.createdAt)}</Text>
             </View>
+            <TouchableOpacity style={styles.headerSvg} onPress={() => {}}>
+              <WithLocalSvg width={79} height={30} asset={SeeOriginalSvg as ImageSourcePropType} />
+            </TouchableOpacity>
           </View>
-        )}
-        <Text style={styles.subtitleText}>통합 베스트 Top 5 의견</Text>
-        <TopOpinionSlider id={1} />
-        <View style={styles.divideLine}></View>
-        <View style={styles.mainCategoryContainer}>
-          <TouchableOpacity
-            onPress={() => SelectMainCategory(mainCategories[0])}
-            style={{
-              flexDirection: 'column',
-              height: 36,
-              width: 31,
-              gap: 12,
-              alignItems: 'center',
-            }}
-          >
-            <Text
-              style={[
-                styles.baseText,
-                activeMainCategory === mainCategories[0] && styles.activeText,
-              ]}
-            >
-              {mainCategories[0]}
-            </Text>
-            {activeMainCategory === mainCategories[0] && <View style={styles.selectedBar} />}
-          </TouchableOpacity>
-          <TouchableOpacity
-            onPress={() => SelectMainCategory(mainCategories[1])}
-            style={{
-              flexDirection: 'column',
-              height: 36,
-              width: 80,
-              gap: 12,
-              alignItems: 'center',
-            }}
-          >
-            <Text
-              style={[
-                styles.baseText,
-                activeMainCategory === mainCategories[1] && styles.activeText,
-              ]}
-            >
-              {mainCategories[1]}
-            </Text>
-            {activeMainCategory === mainCategories[1] && <View style={styles.selectedBar} />}
-          </TouchableOpacity>
         </View>
-        <View style={styles.headerUnderLine} />
-        {activeMainCategory === mainCategories[0] ? (
-          <TotalOpinionCategory issueId={1} />
-        ) : (
-          <ParagraphOpinionCategory issueId={1} />
-        )}
-      </ScrollView>
+      )}
+      <Text style={styles.subtitleText}>통합 베스트 Top 5 의견</Text>
+      <TopOpinionSlider id={1} />
+      <View style={styles.divideLine}></View>
+      <View style={styles.mainCategoryContainer}>
+        <TouchableOpacity
+          onPress={() => SelectMainCategory(mainCategories[0])}
+          style={{
+            flexDirection: 'column',
+            height: 36,
+            gap: 12,
+            alignItems: 'center',
+          }}
+        >
+          <Text
+            style={[styles.baseText, activeMainCategory === mainCategories[0] && styles.activeText]}
+          >
+            {mainCategories[0]}
+          </Text>
+          {activeMainCategory === mainCategories[0] && <View style={styles.selectedBar} />}
+        </TouchableOpacity>
+        <TouchableOpacity
+          onPress={() => SelectMainCategory(mainCategories[1])}
+          style={{
+            flexDirection: 'column',
+            height: 36,
+            gap: 12,
+            alignItems: 'center',
+          }}
+        >
+          <Text
+            style={[styles.baseText, activeMainCategory === mainCategories[1] && styles.activeText]}
+          >
+            {mainCategories[1]}
+          </Text>
+          {activeMainCategory === mainCategories[1] && <View style={styles.selectedBar} />}
+        </TouchableOpacity>
+      </View>
+      <View style={styles.headerUnderLine} />
+      {activeMainCategory === mainCategories[0] ? (
+        <TotalOpinionCategory issueId={1} />
+      ) : (
+        <ParagraphOpinionCategory issueId={1} />
+      )}
     </ScrollView>
   );
 };

--- a/src/pages/OpinionMainPage.tsx
+++ b/src/pages/OpinionMainPage.tsx
@@ -70,7 +70,6 @@ const OpinionMainPage = () => {
               width: 31,
               gap: 12,
               alignItems: 'center',
-              backgroundColor: theme.color.gray5
             }}
           >
             <Text
@@ -91,7 +90,6 @@ const OpinionMainPage = () => {
               width: 80,
               gap: 12,
               alignItems: 'center',
-              backgroundColor: theme.color.gray5
             }}
           >
             <Text

--- a/src/pages/OpinionMainPage.tsx
+++ b/src/pages/OpinionMainPage.tsx
@@ -58,6 +58,7 @@ const OpinionMainPage = () => {
             </View>
           </View>
         )}
+        <Text style={styles.subtitleText}>통합 베스트 Top 5 의견</Text>
         <TopOpinionSlider id={1} />
         <View style={styles.divideLine}></View>
         <View style={styles.mainCategoryTop}>
@@ -209,6 +210,17 @@ const styles = StyleSheet.create({
   },
   headerSvg: {
     justifyContent: 'flex-end',
+  },
+  subtitleText: {
+    paddingHorizontal: 26,
+    fontFamily: fontFamily.pretendard.bold,
+    fontSize: 17,
+    fontStyle: 'normal',
+    fontWeight: '700',
+    lineHeight: 25.5,
+    letterSpacing: -0.51,
+    color: theme.color.white,
+    width: '100%',
   },
 });
 

--- a/src/pages/OpinionMainPage.tsx
+++ b/src/pages/OpinionMainPage.tsx
@@ -61,25 +61,47 @@ const OpinionMainPage = () => {
         <Text style={styles.subtitleText}>통합 베스트 Top 5 의견</Text>
         <TopOpinionSlider id={1} />
         <View style={styles.divideLine}></View>
-        <View style={styles.mainCategoryTop}>
-          {mainCategories.map((category) => (
-            <TouchableOpacity
-              key={category}
-              style={styles.mainCategory}
-              onPress={() => SelectMainCategory(category)}
+        <View style={styles.mainCategoryContainer}>
+          <TouchableOpacity
+            onPress={() => SelectMainCategory(mainCategories[0])}
+            style={{
+              flexDirection: 'column',
+              height: 36,
+              width: 28,
+              gap: 12,
+            }}
+          >
+            <Text
+              style={[
+                styles.baseText,
+                activeMainCategory === mainCategories[0] && styles.activeText,
+              ]}
             >
-              <Text style={[styles.baseText, activeMainCategory === category && styles.activeText]}>
-                {category}
-              </Text>
-            </TouchableOpacity>
-          ))}
+              {mainCategories[0]}
+            </Text>
+            {activeMainCategory === mainCategories[0] && <View style={styles.selectedBar} />}
+          </TouchableOpacity>
+          <TouchableOpacity
+            onPress={() => SelectMainCategory(mainCategories[1])}
+            style={{
+              flexDirection: 'column',
+              height: 36,
+              width: 71,
+              gap: 12,
+            }}
+          >
+            <Text
+              style={[
+                styles.baseText,
+                activeMainCategory === mainCategories[1] && styles.activeText,
+              ]}
+            >
+              {mainCategories[1]}
+            </Text>
+            {activeMainCategory === mainCategories[1] && <View style={styles.selectedBar} />}
+          </TouchableOpacity>
         </View>
-        <View>
-          <View style={styles.headerUnderLine} />
-          {activeMainCategory == mainCategories[0] && <View style={styles.selectedAll} />}
-          {activeMainCategory == mainCategories[1] && <View style={styles.selectedParagraph} />}
-        </View>
-
+        <View style={styles.headerUnderLine} />
         {activeMainCategory === mainCategories[0] ? (
           <TotalOpinionCategory issueId={1} />
         ) : (
@@ -113,8 +135,10 @@ const styles = StyleSheet.create({
     marginLeft: 26,
     marginTop: 18,
   },
-  mainCategory: {
-    marginRight: 18,
+  mainCategoryContainer: {
+    marginLeft: 26,
+    flexDirection: 'row',
+    gap: 18,
   },
   activeText: {
     fontSize: 16,
@@ -150,21 +174,9 @@ const styles = StyleSheet.create({
   buttonWrapper: {
     position: 'relative',
   },
-  selectedAll: {
-    position: 'absolute',
+  selectedBar: {
     bottom: 1,
-    left: 26,
-    right: 0,
-    width: 30,
-    height: 4,
-    backgroundColor: theme.color.white,
-  },
-  selectedParagraph: {
-    position: 'absolute',
-    bottom: 1,
-    left: 75,
-    right: 0,
-    width: 79,
+    width: '100%',
     height: 4,
     backgroundColor: theme.color.white,
   },

--- a/src/pages/OpinionMainPage.tsx
+++ b/src/pages/OpinionMainPage.tsx
@@ -67,8 +67,10 @@ const OpinionMainPage = () => {
             style={{
               flexDirection: 'column',
               height: 36,
-              width: 28,
+              width: 31,
               gap: 12,
+              alignItems: 'center',
+              backgroundColor: theme.color.gray5
             }}
           >
             <Text
@@ -86,8 +88,10 @@ const OpinionMainPage = () => {
             style={{
               flexDirection: 'column',
               height: 36,
-              width: 71,
+              width: 80,
               gap: 12,
+              alignItems: 'center',
+              backgroundColor: theme.color.gray5
             }}
           >
             <Text
@@ -175,7 +179,7 @@ const styles = StyleSheet.create({
     position: 'relative',
   },
   selectedBar: {
-    bottom: 1,
+    bottom: 5,
     width: '100%',
     height: 4,
     backgroundColor: theme.color.white,

--- a/src/pages/ReprocessedIssueDetailPage.tsx
+++ b/src/pages/ReprocessedIssueDetailPage.tsx
@@ -1,5 +1,12 @@
 import React, { useEffect } from 'react';
-import { ActivityIndicator, ScrollView, StyleSheet, Text, View } from 'react-native';
+import {
+  ActivityIndicator,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
 import theme from '../shared/styles/theme';
 import ReprocessedIssueContentsSlider from '../features/remakeissue/components/ReprocessedIssueContentsSlider';
 import OpinionWriteSlider from '../features/remakeissue/components/OpinionWriteSlider';
@@ -16,6 +23,8 @@ import { useSetRecoilState } from 'recoil';
 import { issueNumberState } from '../recoil/issueState';
 import { bookmarkState } from '../recoil/bookmarkState';
 import { bookmarkInfo } from '../features/remakeissue/types/bookmark';
+import TopOpinionSlider from '../features/vote/components/TopOpinionSlider';
+import fontFamily from '../shared/styles/fontFamily';
 const ReprocessedIssueDetailPage: React.FC = () => {
   const navigation = useNavigation<StackNavigationProp<RootStackParamList>>();
   type ScreenRouteProp = RouteProp<RootStackParamList, 'ReprocessedIssueDetailPage'>;
@@ -26,6 +35,9 @@ const ReprocessedIssueDetailPage: React.FC = () => {
   const setBookmarkState = useSetRecoilState<bookmarkInfo>(bookmarkState);
 
   const fetchReprocessedIssue = () => getReprocessedIssueContent(id);
+  const onClickShowOpinionButton = () => {
+    navigation.navigate('OpinionMainPage', { id: id });
+  };
   const {
     data: reprocessedIssue,
     isLoading,
@@ -69,7 +81,11 @@ const ReprocessedIssueDetailPage: React.FC = () => {
         <View style={styles.divideLine} />
         <OpinionWriteSlider navigation={navigation} issueId={id} />
         <View style={styles.divideLine} />
-        <ReliabilityEvaluation navigation={navigation} issueId={id} />
+        <TopOpinionSlider id={id} />
+        <TouchableOpacity style={styles.opinionPageButton} onPress={onClickShowOpinionButton}>
+          <Text style={styles.totalVotedButtonText}>의견 보기</Text>
+        </TouchableOpacity>
+        {/*<ReliabilityEvaluation navigation={navigation} issueId={id} />*/}
         <View style={styles.divideLine} />
         {reprocessedIssue !== null && (
           <CategoryLatestNews current={id} category={reprocessedIssue.category} />
@@ -122,6 +138,29 @@ const styles = StyleSheet.create({
   activityIndicator: {
     flex: 1,
     alignSelf: 'center',
+  },
+  opinionPageButton: {
+    display: 'flex',
+    borderRadius: 10,
+    width: 160,
+    height: 50,
+    justifyContent: 'center',
+    alignSelf: 'center',
+    alignItems: 'center',
+    flexShrink: 0,
+    backgroundColor: theme.color.gray3,
+    marginTop: 28,
+    marginBottom: 20,
+  },
+  totalVotedButtonText: {
+    fontFamily: fontFamily.pretendard.bold,
+    fontSize: 17,
+    fontStyle: 'normal',
+    fontWeight: '700',
+    lineHeight: 25.5,
+    letterSpacing: -0.51,
+    color: theme.color.white,
+    textAlign: 'center',
   },
 });
 

--- a/src/pages/ReprocessedIssueDetailPage.tsx
+++ b/src/pages/ReprocessedIssueDetailPage.tsx
@@ -25,6 +25,8 @@ import { bookmarkState } from '../recoil/bookmarkState';
 import { bookmarkInfo } from '../features/remakeissue/types/bookmark';
 import TopOpinionSlider from '../features/vote/components/TopOpinionSlider';
 import fontFamily from '../shared/styles/fontFamily';
+import { getMyOpinionWrite } from '../features/remakeissue/remotes/opinionWrite';
+import EmptyScreen from '../shared/components/Opinion/EmptyScreen';
 const ReprocessedIssueDetailPage: React.FC = () => {
   const navigation = useNavigation<StackNavigationProp<RootStackParamList>>();
   type ScreenRouteProp = RouteProp<RootStackParamList, 'ReprocessedIssueDetailPage'>;
@@ -33,6 +35,9 @@ const ReprocessedIssueDetailPage: React.FC = () => {
 
   const setIssueState = useSetRecoilState<number>(issueNumberState);
   const setBookmarkState = useSetRecoilState<bookmarkInfo>(bookmarkState);
+
+  const fetchMyOpinionWrite = () => getMyOpinionWrite(id);
+  const { data: myOpinionWrite } = useFetch(fetchMyOpinionWrite, false);
 
   const fetchReprocessedIssue = () => getReprocessedIssueContent(id);
   const onClickShowOpinionButton = () => {
@@ -72,7 +77,6 @@ const ReprocessedIssueDetailPage: React.FC = () => {
       </View>
     );
   }
-
   return (
     <View style={styles.container}>
       <View style={styles.headerUnderLine} />
@@ -81,10 +85,22 @@ const ReprocessedIssueDetailPage: React.FC = () => {
         <View style={styles.divideLine} />
         <OpinionWriteSlider navigation={navigation} issueId={id} />
         <View style={styles.divideLine} />
-        <TopOpinionSlider id={id} />
-        <TouchableOpacity style={styles.opinionPageButton} onPress={onClickShowOpinionButton}>
-          <Text style={styles.totalVotedButtonText}>의견 보기</Text>
-        </TouchableOpacity>
+        <View style={{ marginTop: 20 }}>
+          <Text style={styles.titleText}>통합 베스트 Top 5 의견</Text>
+        </View>
+        {Array.isArray(myOpinionWrite) && myOpinionWrite.length === 0 ? (
+          <View style={styles.emptyContainer}>
+            <EmptyScreen text={'의견을 남기면 확인할 수 있습니다.'} />
+          </View>
+        ) : (
+          <View>
+            <TopOpinionSlider id={id} />
+            <TouchableOpacity style={styles.opinionPageButton} onPress={onClickShowOpinionButton}>
+              <Text style={styles.totalVotedButtonText}>의견 보기</Text>
+            </TouchableOpacity>
+          </View>
+        )}
+
         {/*<ReliabilityEvaluation navigation={navigation} issueId={id} />*/}
         <View style={styles.divideLine} />
         {reprocessedIssue !== null && (
@@ -161,6 +177,21 @@ const styles = StyleSheet.create({
     letterSpacing: -0.51,
     color: theme.color.white,
     textAlign: 'center',
+  },
+  titleText: {
+    paddingHorizontal: 26,
+    fontFamily: fontFamily.pretendard.bold,
+    fontSize: 17,
+    fontStyle: 'normal',
+    fontWeight: '700',
+    lineHeight: 25.5,
+    letterSpacing: -0.51,
+    color: theme.color.white,
+    width: '100%',
+  },
+  emptyContainer: {
+    marginTop: 30,
+    marginBottom: 10,
   },
 });
 


### PR DESCRIPTION
## 💬리뷰 참고사항
- 메인 페이지 워딩 변경
- 신뢰도 평가 -> 주석 처리
- 카테고리 1,2 -> 주석 처리
- top5의견 위치 수정
   - 아래 사진과 같이 신뢰도 평가하기 위치에 top5 의견을 옮겼습니다.
<img width="271" alt="image" src="https://github.com/Neupinion/Neupinion-App/assets/95111439/0dfa6d9f-b7dd-4f51-8b6b-5978e23bfd3d">

- 전체/문단별 보기 밑에 하얀 바 크기를 동적으로 변하게 수정하였습니다. (패드, 핸드폰)
<img width="631" alt="image" src="https://github.com/Neupinion/Neupinion-App/assets/95111439/3e85f4f4-4198-4667-8c48-e9ae0caa0e69">
<img width="343" alt="image" src="https://github.com/Neupinion/Neupinion-App/assets/95111439/95f36038-96a3-4464-83cc-8e02922474c5">



👐 **+ (논의하고 싶은 내용) 사용자가 의견을 남길시 top5 의견을 보게 수정하는 걸로 바꾸는거 어떨까요?
이유는 사용자가 의견을 남길시 다른 사람의 의견에 영향을 받지 않도록 하기 위해서 입니다.**
-> UI에상에서는 이렇게 보여집니다. 참고바랍니다!
<img width="338" alt="image" src="https://github.com/Neupinion/Neupinion-App/assets/95111439/bc469f25-de69-4554-86d7-61070af1cab4">



## #️⃣연관된 이슈

closes #116 