### PR TITLE
fix: 기존의 유효한 토큰이 존재하면, 바로 소셜 로그인이 가능하도록 수정

### DIFF
--- a/src/features/auth/constants/userAgent.ts
+++ b/src/features/auth/constants/userAgent.ts
@@ -2,5 +2,5 @@ import { Platform } from 'react-native';
 
 export const userAgent =
   Platform.OS === 'android'
-    ? 'Chrome/18.0.1025.133 Mobile Safari/535.19'
-    : 'AppleWebKit/602.1.50 (KHTML, like Gecko) CriOS/56.0.2924.75';
+    ? 'Mozilla/5.0 (Linux; Android 9; SM-G950N) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/88.0.4324.93 Mobile Safari/537.36'
+    : 'Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.0 Mobile/15E148 Safari/604.1';

--- a/src/features/auth/remotes/googleLogin.ts
+++ b/src/features/auth/remotes/googleLogin.ts
@@ -8,11 +8,20 @@ export const getAccessTokenGoogle = async (
   event: WebViewNavigation,
   closeWebView: () => void,
 ): Promise<TokenResponse | null> => {
+  const storedAccessToken = await AsyncStorage.getItem('accessToken');
+  const storedRefreshToken = await AsyncStorage.getItem('refreshTokenCookie');
+
+  if (storedAccessToken && storedRefreshToken) {
+    closeWebView();
+    return { accessToken: storedAccessToken, refreshToken: storedRefreshToken };
+  }
+
   const url = event.url;
   if (url.includes(`${API_URL}/login/google`)) {
     const code = new URL(url).searchParams.get('code');
     if (code) {
       try {
+        closeWebView();
         const response = await client.get(`${API_URL}/login/google`, {
           params: { code: code },
         });
@@ -29,7 +38,6 @@ export const getAccessTokenGoogle = async (
             const { accessToken } = data;
             await AsyncStorage.setItem('refreshTokenCookie', refreshToken);
             await AsyncStorage.setItem('accessToken', accessToken);
-            closeWebView();
             console.log(accessToken, refreshToken);
             return { accessToken, refreshToken };
           }

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from "react";
 import { ImageSourcePropType, StyleSheet, Text, TouchableOpacity, View, Modal } from 'react-native';
 import { WebView, WebViewNavigation } from 'react-native-webview';
 import theme from '../shared/styles/theme';
@@ -20,10 +20,10 @@ import { socialAuthIcons, socialAuthTexts } from '../features/auth/constants/soc
 import { useNavigation } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
 import { RootStackParamList } from '../rootStackParamList';
+import AsyncStorage from "@react-native-async-storage/async-storage";
 
 const LoginPage: React.FC = () => {
   const navigation = useNavigation<StackNavigationProp<RootStackParamList>>();
-
   const [webView, setWebView] = useRecoilState(webViewState);
 
   const closeWebView = () => {


### PR DESCRIPTION
## 💬리뷰 참고사항

- 구글 및 페이스북과 같은 플랫폼의 로그인 기능을 웹뷰에서 사용하려는 경우, 일반적으로 보안 상의 이유로, User Agent라는 헤더를 사용하여 인증 요청을 하게 됩니다. 일반적으로 사용하는 User Agent로 변경하였더니, 로그인 요청 후에 토큰과 오류가 동시에 오는 오류, 웹뷰가 종료되지 않는 오류가 해결되었습니다.
- 사용자에게 기존에 유효한 토큰이 존재하면, 별도의 인증 과정 없이 로그인이 진행되도록 수정하였습니다.

## #️⃣연관된 이슈

> 연관된 이슈 번호를 모두 작성

 closes #121 
